### PR TITLE
Added AlbumSort compatibility

### DIFF
--- a/include/mpd/tag.h
+++ b/include/mpd/tag.h
@@ -69,6 +69,8 @@ enum mpd_tag_type
 	MPD_TAG_ARTIST_SORT,
 	MPD_TAG_ALBUM_ARTIST_SORT,
 
+	MPD_TAG_ALBUM_SORT,
+
 	/* IMPORTANT: the ordering of tag types above must be
 	   retained, or else the libmpdclient ABI breaks */
 

--- a/src/tag.c
+++ b/src/tag.c
@@ -41,6 +41,7 @@ static const char *const mpd_tag_type_names[MPD_TAG_COUNT] =
 	[MPD_TAG_ARTIST] = "Artist",
 	[MPD_TAG_ARTIST_SORT] = "ArtistSort",
 	[MPD_TAG_ALBUM] = "Album",
+	[MPD_TAG_ALBUM_SORT] = "AlbumSort",
 	[MPD_TAG_ALBUM_ARTIST] = "AlbumArtist",
 	[MPD_TAG_ALBUM_ARTIST_SORT] = "AlbumArtistSort",
 	[MPD_TAG_TITLE] = "Title",


### PR DESCRIPTION
Allows the user to use the AlbumSort tag, simlar to ArtistSort and
AlbumArtistSort.  This allows a user to ignore "The" or "A(n)", preventing having essentially a subsort with this words.