### PR TITLE
meson.build: fix build with meson > 0.38.1

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -89,7 +89,7 @@ inc = include_directories(
   'include',
 
   # for the generated config.h
-  meson.current_build_dir(),
+  '.',
 )
 
 libmpdclient = library('mpdclient',


### PR DESCRIPTION
Fixes the error "Tried to form an absolute path to a source dir. You
should not do that but use relative paths instead."