### PR TITLE
Support for searchaddpl command

### DIFF
--- a/include/mpd/search.h
+++ b/include/mpd/search.h
@@ -92,6 +92,18 @@ bool
 mpd_search_add_db_songs(struct mpd_connection *connection, bool exact);
 
 /**
+ * Search for songs in the database and adds the result to a playlist
+ * Constraints may be specified with mpd_search_add_tag_constraint().
+ * Send the search command with mpd_search_commit().
+ *
+ * @param connection the connection to MPD
+ * @param exact if to match exact (only "true" supported by MPD 0.16)
+ * @return true on success, false on error
+ */
+bool
+mpd_search_add_pl_db_songs(struct mpd_connection *connection);
+
+/**
  * Search for songs in the queue.
  * Constraints may be specified with mpd_search_add_tag_constraint().
  * Send the search command with mpd_search_commit(), and read the
@@ -142,6 +154,21 @@ bool
 mpd_search_add_base_constraint(struct mpd_connection *connection,
 			       enum mpd_operator oper,
 			       const char *value);
+
+/**
+ * Adds the playlist for search_add_pl_db_songs.
+ *
+ * @param connection a #mpd_connection
+ * @param oper reserved, pass #MPD_OPERATOR_DEFAULT
+ * @param value the URI relative to the music directory
+ * @return true on success, false on error
+ *
+ * @since libmpdclient 2.9
+ */
+bool
+mpd_search_add_pl_constraint(struct mpd_connection *connection,
+                               enum mpd_operator oper,
+                               const char *value);
 
 /**
  * Add a constraint on the song's URI.

--- a/include/mpd/search.h
+++ b/include/mpd/search.h
@@ -93,6 +93,7 @@ mpd_search_add_db_songs(struct mpd_connection *connection, bool exact);
 
 /**
  * Search for songs in the database and adds the result to a playlist
+ * Playlist must be specified with mpd_search_add_pl_constraint().
  * Constraints may be specified with mpd_search_add_tag_constraint().
  * Send the search command with mpd_search_commit().
  *

--- a/include/mpd/search.h
+++ b/include/mpd/search.h
@@ -102,7 +102,7 @@ mpd_search_add_db_songs(struct mpd_connection *connection, bool exact);
  * @return true on success, false on error
  */
 bool
-mpd_search_add_pl_db_songs(struct mpd_connection *connection);
+mpd_search_add_pl_db_songs(struct mpd_connection *connection, const char *value);
 
 /**
  * Search for songs in the queue.
@@ -155,21 +155,6 @@ bool
 mpd_search_add_base_constraint(struct mpd_connection *connection,
 			       enum mpd_operator oper,
 			       const char *value);
-
-/**
- * Adds the playlist for search_add_pl_db_songs.
- *
- * @param connection a #mpd_connection
- * @param oper reserved, pass #MPD_OPERATOR_DEFAULT
- * @param value the URI relative to the music directory
- * @return true on success, false on error
- *
- * @since libmpdclient 2.9
- */
-bool
-mpd_search_add_pl_constraint(struct mpd_connection *connection,
-                               enum mpd_operator oper,
-                               const char *value);
 
 /**
  * Add a constraint on the song's URI.

--- a/libmpdclient.ld
+++ b/libmpdclient.ld
@@ -310,7 +310,6 @@ global:
 	mpd_search_add_base_constraint;
 	mpd_search_add_uri_constraint;
 	mpd_search_add_tag_constraint;
-	mpd_search_add_pl_constraint;
 	mpd_search_add_any_tag_constraint;
 	mpd_search_add_modified_since_constraint;
 	mpd_search_add_expression;

--- a/libmpdclient.ld
+++ b/libmpdclient.ld
@@ -303,12 +303,14 @@ global:
 	/* mpd/search.h */
 	mpd_search_db_songs;
 	mpd_search_add_db_songs;
+	mpd_search_add_pl_db_songs;
 	mpd_search_queue_songs;
 	mpd_search_db_tags;
 	mpd_count_db_songs;
 	mpd_search_add_base_constraint;
 	mpd_search_add_uri_constraint;
 	mpd_search_add_tag_constraint;
+	mpd_search_add_pl_constraint;
 	mpd_search_add_any_tag_constraint;
 	mpd_search_add_modified_since_constraint;
 	mpd_search_add_expression;

--- a/src/search.c
+++ b/src/search.c
@@ -229,10 +229,30 @@ mpd_search_add_base_constraint(struct mpd_connection *connection,
 
 bool
 mpd_search_add_pl_constraint(struct mpd_connection *connection,
-			       enum mpd_operator oper,
+			       mpd_unused enum mpd_operator oper,
 			       const char *value)
 {
-	return mpd_search_add_pl_constraint(connection, oper, value);
+	assert(connection != NULL);
+	assert(value != NULL);
+
+	char *arg = mpd_sanitize_arg(value);
+	if (arg == NULL) {
+		mpd_error_code(&connection->error, MPD_ERROR_OOM);
+		return false;
+	}
+
+	const size_t add_length = 2 + strlen(arg) + 1;
+
+	char *dest = mpd_search_prepare_append(connection, add_length);
+	if (dest == NULL) {
+		free(arg);
+		return false;
+	}
+
+	sprintf(dest, " \"%s\"", arg);
+
+	free(arg);
+	return true;
 }
 
 bool

--- a/src/search.c
+++ b/src/search.c
@@ -82,6 +82,12 @@ mpd_search_add_db_songs(struct mpd_connection *connection, bool exact)
 }
 
 bool
+mpd_search_add_pl_db_songs(struct mpd_connection *connection)
+{
+	return mpd_search_init(connection, "searchaddpl");
+}
+
+bool
 mpd_search_queue_songs(struct mpd_connection *connection, bool exact)
 {
 	return mpd_search_init(connection,
@@ -212,12 +218,21 @@ mpd_search_add_constraint(struct mpd_connection *connection,
 	free(arg);
 	return true;
 }
+
 bool
 mpd_search_add_base_constraint(struct mpd_connection *connection,
 			       enum mpd_operator oper,
 			       const char *value)
 {
 	return mpd_search_add_constraint(connection, oper, "base", value);
+}
+
+bool
+mpd_search_add_pl_constraint(struct mpd_connection *connection,
+			       enum mpd_operator oper,
+			       const char *value)
+{
+	return mpd_search_add_pl_constraint(connection, oper, value);
 }
 
 bool


### PR DESCRIPTION
Adds support for searchaddpl command.
- ```mpd_search_add_pl_db_songs``` - base command, returns searchaddpl
- ```mpd_search_add_pl_constraint``` - adds the playlist to the search

This pull request fixes my issue #11 