### PR TITLE
adds low level functions to support binary data

### DIFF
--- a/include/mpd/async.h
+++ b/include/mpd/async.h
@@ -1,5 +1,5 @@
 /* libmpdclient
-   (c) 2003-2018 The Music Player Daemon Project
+   (c) 2003-2019 The Music Player Daemon Project
    This project's homepage is: http://www.musicpd.org
 
    Redistribution and use in source and binary forms, with or without
@@ -46,6 +46,7 @@
 
 #include <stdbool.h>
 #include <stdarg.h>
+#include <stddef.h>
 
 /**
  * Event bit mask for polling.
@@ -102,9 +103,9 @@ enum mpd_error
 mpd_async_get_error(const struct mpd_async *async);
 
 /**
- * If mpd_async_is_alive() returns false, this function returns the
- * human readable error message which caused this.  This message is
- * optional, and may be NULL.  The pointer is invalidated by
+ * If mpd_async_get_error() returns an error code other than #MPD_ERROR_SUCCESS,
+ * this function returns the human readable error message which caused this.
+ * This message is optional, and may be NULL.  The pointer is invalidated by
  * mpd_async_free().
  *
  * For #MPD_ERROR_SERVER, the error message is encoded in UTF-8.
@@ -148,10 +149,11 @@ mpd_async_get_fd(const struct mpd_async *async);
  *
  * @param async the #mpd_async object
  * @param keepalive whether TCP keepalives should be enabled
+ * @return true on success, false if setsockopt failed
  *
  * @since libmpdclient 2.10
  */
-void
+bool
 mpd_async_set_keepalive(struct mpd_async *async,
 			bool keepalive);
 
@@ -178,8 +180,9 @@ mpd_async_io(struct mpd_async *async, enum mpd_async_event events);
  * @param async the connection
  * @param command the command name, followed by arguments, terminated by
  * NULL
- * @param args the argument list
- * @return true on success, false if the buffer is full
+ * @param args the list of 'const char *' arguments
+ * @return true on success, false if the buffer is full or an error has
+ * previously occurred
  */
 bool
 mpd_async_send_command_v(struct mpd_async *async, const char *command,
@@ -190,8 +193,9 @@ mpd_async_send_command_v(struct mpd_async *async, const char *command,
  *
  * @param async the connection
  * @param command the command name, followed by arguments, terminated by
- * NULL
- * @return true on success, false if the buffer is full
+ * NULL. The arguments should be of type 'const char *'
+ * @return true on success, false if the buffer is full or an error has
+ * previously occurred
  */
 mpd_sentinel
 bool
@@ -220,7 +224,7 @@ mpd_async_recv_line(struct mpd_async *async);
  * @return a pointer to struct mpd_binary, NULL on error or end of buffer.
  */
 struct mpd_binary *
-mpd_async_recv_binary(struct mpd_async *async, struct mpd_binary *buffer, const unsigned length);
+mpd_async_recv_binary(struct mpd_async *async, struct mpd_binary *buffer, size_t length);
 
 #ifdef __cplusplus
 }

--- a/include/mpd/async.h
+++ b/include/mpd/async.h
@@ -209,9 +209,18 @@ mpd_malloc
 char *
 mpd_async_recv_line(struct mpd_async *async);
 
-
-struct mpd_binary
-mpd_async_recv_binary(struct mpd_async *async, const unsigned binary);
+/**
+ * Receives length raw bytes from the input buffer. The result will be
+ * without the newline character. The pointer is only valid until the 
+ * next async function is called. Call this function till it returns NULL.
+ *
+ * @param async the connection
+ * @param buffer pointer to allocated struct mpd_binary
+ * @param length the bytes to return
+ * @return a pointer to struct mpd_binary, NULL on error or end of buffer.
+ */
+struct mpd_binary *
+mpd_async_recv_binary(struct mpd_async *async, struct mpd_binary *buffer, const unsigned length);
 
 #ifdef __cplusplus
 }

--- a/include/mpd/async.h
+++ b/include/mpd/async.h
@@ -216,7 +216,7 @@ mpd_async_recv_line(struct mpd_async *async);
  *
  * @param async the connection
  * @param buffer pointer to allocated struct mpd_binary
- * @param length the bytes to return
+ * @param length of bytes to consume
  * @return a pointer to struct mpd_binary, NULL on error or end of buffer.
  */
 struct mpd_binary *

--- a/include/mpd/async.h
+++ b/include/mpd/async.h
@@ -209,6 +209,10 @@ mpd_malloc
 char *
 mpd_async_recv_line(struct mpd_async *async);
 
+
+struct mpd_binary
+mpd_async_recv_binary(struct mpd_async *async, const unsigned binary);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/mpd/recv.h
+++ b/include/mpd/recv.h
@@ -47,12 +47,14 @@ extern "C" {
 #endif
 
 /**
- * Reads the binary data from the server.  Returns NULL on error.
+ * Reads the binary data from the server.  Returns the length
+ * of consumed bytes.
+ * The size and binary pair must be already read from the input buffer.
  *
- * The caller must free the allocated memory.
+ * The caller must allocate length bytes of memory for data.
  */
-char * 
-mpd_recv_binary(struct mpd_connection *connection, const unsigned binary);
+unsigned
+mpd_recv_binary(struct mpd_connection *connection, unsigned char *data, const unsigned length);
 
 /**
  * Reads the next #mpd_pair from the server.  Returns NULL if there

--- a/include/mpd/recv.h
+++ b/include/mpd/recv.h
@@ -47,6 +47,14 @@ extern "C" {
 #endif
 
 /**
+ * Reads the binary data from the server.  Returns NULL on error.
+ *
+ * The caller must free the allocated memory.
+ */
+char * 
+mpd_recv_binary(struct mpd_connection *connection, const unsigned binary);
+
+/**
  * Reads the next #mpd_pair from the server.  Returns NULL if there
  * are no more pairs.
  *

--- a/include/mpd/recv.h
+++ b/include/mpd/recv.h
@@ -1,5 +1,5 @@
 /* libmpdclient
-   (c) 2003-2018 The Music Player Daemon Project
+   (c) 2003-2019 The Music Player Daemon Project
    This project's homepage is: http://www.musicpd.org
 
    Redistribution and use in source and binary forms, with or without
@@ -39,6 +39,8 @@
 
 #include "compiler.h"
 
+#include <stddef.h>
+
 struct mpd_pair;
 struct mpd_connection;
 
@@ -53,8 +55,8 @@ extern "C" {
  *
  * The caller must allocate length bytes of memory for data.
  */
-unsigned
-mpd_recv_binary(struct mpd_connection *connection, unsigned char *data, unsigned length);
+size_t
+mpd_recv_binary(struct mpd_connection *connection, void *data, size_t length);
 
 /**
  * Reads the next #mpd_pair from the server.  Returns NULL if there

--- a/include/mpd/recv.h
+++ b/include/mpd/recv.h
@@ -47,14 +47,14 @@ extern "C" {
 #endif
 
 /**
- * Reads the binary data from the server.  Returns the length
+ * Reads the binary data response from the server.  Returns the length
  * of consumed bytes.
  * The size and binary pair must be already read from the input buffer.
  *
  * The caller must allocate length bytes of memory for data.
  */
 unsigned
-mpd_recv_binary(struct mpd_connection *connection, unsigned char *data, const unsigned length);
+mpd_recv_binary(struct mpd_connection *connection, unsigned char *data, unsigned length);
 
 /**
  * Reads the next #mpd_pair from the server.  Returns NULL if there

--- a/libmpdclient.ld
+++ b/libmpdclient.ld
@@ -13,6 +13,7 @@ global:
 	mpd_async_send_command_v;
 	mpd_async_send_command;
 	mpd_async_recv_line;
+	mpd_async_recv_binary;
 
 	/* mpd/capabilities.h */
 	mpd_send_allowed_commands;
@@ -295,6 +296,7 @@ global:
 	mpd_recv_pair_named;
 	mpd_return_pair;
 	mpd_enqueue_pair;
+	mpd_recv_binary;
 
 	/* mpd/response.h */
 	mpd_response_finish;

--- a/src/async.c
+++ b/src/async.c
@@ -26,7 +26,7 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <mpd/binary.h>
+#include "binary.h"
 #include "iasync.h"
 #include "buffer.h"
 #include "ierror.h"

--- a/src/async.c
+++ b/src/async.c
@@ -1,5 +1,5 @@
 /* libmpdclient
-   (c) 2003-2018 The Music Player Daemon Project
+   (c) 2003-2019 The Music Player Daemon Project
    This project's homepage is: http://www.musicpd.org
 
    Redistribution and use in source and binary forms, with or without
@@ -25,7 +25,6 @@
    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
-
 
 #include "iasync.h"
 #include "buffer.h"
@@ -139,14 +138,14 @@ mpd_async_get_fd(const struct mpd_async *async)
 	return async->fd;
 }
 
-void
+bool
 mpd_async_set_keepalive(struct mpd_async *async,
 			bool keepalive)
 {
 	assert(async != NULL);
 	assert(async->fd != MPD_INVALID_SOCKET);
 
-	mpd_socket_keepalive(async->fd, keepalive);
+	return mpd_socket_keepalive(async->fd, keepalive) == 0;
 }
 
 enum mpd_async_event
@@ -383,7 +382,7 @@ mpd_async_recv_line(struct mpd_async *async)
 }
 
 struct mpd_binary *
-mpd_async_recv_binary(struct mpd_async *async, struct mpd_binary *buffer, const unsigned length)
+mpd_async_recv_binary(struct mpd_async *async, struct mpd_binary *buffer, size_t length)
 {
 	assert(async != NULL);
 

--- a/src/async.c
+++ b/src/async.c
@@ -31,8 +31,10 @@
 #include "ierror.h"
 #include "quote.h"
 #include "socket.h"
+#include <stddef.h>
 
 #include <mpd/socket.h>
+#include <mpd/binary.h>
 
 #include <assert.h>
 #include <stdbool.h>
@@ -377,5 +379,25 @@ mpd_async_recv_line(struct mpd_async *async)
 	*newline = 0;
 	mpd_buffer_consume(&async->input, newline + 1 - src);
 
+	return src;
+}
+
+struct mpd_binary
+mpd_async_recv_binary(struct mpd_async *async, const unsigned binary)
+{
+	struct mpd_binary src;
+
+	assert(async != NULL);
+	src.size = mpd_buffer_size(&async->input);
+	src.data = NULL;
+	if (src.size == 0)
+		return src;
+
+	src.data = mpd_buffer_read(&async->input);
+	assert(src.data != NULL);
+
+	src.size = binary < src.size ? binary : src.size;
+	mpd_buffer_consume(&async->input, src.size);
+		
 	return src;
 }

--- a/src/binary.h
+++ b/src/binary.h
@@ -39,19 +39,12 @@
 #ifndef MPD_BINARY_H
 #define MPD_BINARY_H
 
-#include <mpd/compiler.h>
-
-#include <stdbool.h>
-#include <stddef.h>
-
-struct mpd_connection;
-
 struct mpd_binary {
         /** the binary data */
-        char *data;
+        unsigned char *data;
 
         /** the size of the binary data */
-        size_t size;
+        unsigned size;
 };
 
 #endif

--- a/src/binary.h
+++ b/src/binary.h
@@ -39,12 +39,14 @@
 #ifndef MPD_BINARY_H
 #define MPD_BINARY_H
 
+#include <stdlib.h>
+
 struct mpd_binary {
         /** the binary data */
-        unsigned char *data;
+        void *data;
 
         /** the size of the binary data */
-        unsigned size;
+        size_t size;
 };
 
 #endif

--- a/src/binary.h
+++ b/src/binary.h
@@ -1,5 +1,5 @@
 /* libmpdclient
-   (c) 2003-2018 The Music Player Daemon Project
+   (c) 2003-2019 The Music Player Daemon Project
    This project's homepage is: http://www.musicpd.org
 
    Redistribution and use in source and binary forms, with or without
@@ -12,6 +12,10 @@
    - Redistributions in binary form must reproduce the above copyright
    notice, this list of conditions and the following disclaimer in the
    documentation and/or other materials provided with the distribution.
+
+   - Neither the name of the Music Player Daemon nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
    ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -27,51 +31,27 @@
 */
 
 /*! \file
- * \brief Synchronous MPD connections
+ * \brief MPD client library
  *
- * This library provides synchronous access to a mpd_async object.
- * For all operations, you may provide a timeout.
+ * Do not include this header directly.  Use mpd/client.h instead.
  */
 
-#ifndef MPD_SYNC_H
-#define MPD_SYNC_H
+#ifndef MPD_BINARY_H
+#define MPD_BINARY_H
 
 #include <mpd/compiler.h>
 
 #include <stdbool.h>
-#include <stdarg.h>
+#include <stddef.h>
 
-struct timeval;
-struct mpd_async;
+struct mpd_connection;
 
-/**
- * Synchronous wrapper for mpd_async_send_command_v().
- */
-bool
-mpd_sync_send_command_v(struct mpd_async *async, const struct timeval *tv,
-			const char *command, va_list args);
+struct mpd_binary {
+        /** the binary data */
+        char *data;
 
-/**
- * Synchronous wrapper for mpd_async_send_command().
- */
-mpd_sentinel
-bool
-mpd_sync_send_command(struct mpd_async *async, const struct timeval *tv,
-		      const char *command, ...);
-
-/**
- * Sends all pending data from the output buffer to MPD.
- */
-bool
-mpd_sync_flush(struct mpd_async *async, const struct timeval *tv);
-
-/**
- * Synchronous wrapper for mpd_async_recv_line().
- */
-char *
-mpd_sync_recv_line(struct mpd_async *async, const struct timeval *tv);
-
-struct mpd_binary
-mpd_sync_recv_binary(struct mpd_async *async, const struct timeval *tv, const unsigned binary);
+        /** the size of the binary data */
+        size_t size;
+};
 
 #endif

--- a/src/binary.h
+++ b/src/binary.h
@@ -39,12 +39,11 @@
 #ifndef MPD_BINARY_H
 #define MPD_BINARY_H
 
-#include <stdlib.h>
+#include <stddef.h>
 
 struct mpd_binary {
         /** the binary data */
         void *data;
-
         /** the size of the binary data */
         size_t size;
 };

--- a/src/recv.c
+++ b/src/recv.c
@@ -27,7 +27,7 @@
 */
 
 #include <mpd/recv.h>
-#include <mpd/binary.h>
+#include "binary.h"
 #include <mpd/pair.h>
 #include <mpd/parser.h>
 #include "internal.h"

--- a/src/recv.c
+++ b/src/recv.c
@@ -1,5 +1,5 @@
 /* libmpdclient
-   (c) 2003-2018 The Music Player Daemon Project
+   (c) 2003-2019 The Music Player Daemon Project
    This project's homepage is: http://www.musicpd.org
 
    Redistribution and use in source and binary forms, with or without
@@ -37,8 +37,8 @@
 #include <string.h>
 #include <stdlib.h>
 
-unsigned 
-mpd_recv_binary(struct mpd_connection *connection, unsigned char *data, unsigned length)
+size_t
+mpd_recv_binary(struct mpd_connection *connection, void *data, size_t length)
 {
 	assert(connection != NULL);
 
@@ -58,8 +58,8 @@ mpd_recv_binary(struct mpd_connection *connection, unsigned char *data, unsigned
 					      length - consumed)
 		) != NULL)
 	{
-        	memcpy(data + consumed, binary->data, binary->size);
-                consumed += binary->size;
+		memcpy(((unsigned char *)data) + consumed, binary->data, binary->size);
+		consumed += binary->size;
         }
 
         return consumed;

--- a/src/recv.c
+++ b/src/recv.c
@@ -27,18 +27,18 @@
 */
 
 #include <mpd/recv.h>
-#include "binary.h"
 #include <mpd/pair.h>
 #include <mpd/parser.h>
 #include "internal.h"
 #include "iasync.h"
+#include "binary.h"
 #include "sync.h"
 
 #include <string.h>
 #include <stdlib.h>
 
 unsigned 
-mpd_recv_binary(struct mpd_connection *connection, unsigned char *data, const unsigned length)
+mpd_recv_binary(struct mpd_connection *connection, unsigned char *data, unsigned length)
 {
 	assert(connection != NULL);
 
@@ -58,16 +58,8 @@ mpd_recv_binary(struct mpd_connection *connection, unsigned char *data, const un
 					      length - consumed)
 		) != NULL)
 	{
-                if (binary != NULL && 
-		    binary->size > 0 &&
-		    binary->data != NULL &&
-                    length >= consumed + binary->size) {
-                	memcpy(data + consumed, binary->data, binary->size);
-                	consumed += binary->size;
-		}
-		else {
-			return 0;
-		}
+        	memcpy(data + consumed, binary->data, binary->size);
+                consumed += binary->size;
         }
 
         return consumed;

--- a/src/recv.c
+++ b/src/recv.c
@@ -37,7 +37,7 @@
 #include <string.h>
 #include <stdlib.h>
 
-size_t 
+unsigned 
 mpd_recv_binary(struct mpd_connection *connection, unsigned char *data, const unsigned length)
 {
 	assert(connection != NULL);

--- a/src/sync.c
+++ b/src/sync.c
@@ -1,5 +1,5 @@
 /* libmpdclient
-   (c) 2003-2018 The Music Player Daemon Project
+   (c) 2003-2019 The Music Player Daemon Project
    This project's homepage is: http://www.musicpd.org
 
    Redistribution and use in source and binary forms, with or without
@@ -185,7 +185,7 @@ mpd_sync_recv_line(struct mpd_async *async, const struct timeval *tv0)
 }
 
 struct mpd_binary *
-mpd_sync_recv_binary(struct mpd_async *async, const struct timeval *tv0, struct mpd_binary *buffer, const unsigned length)
+mpd_sync_recv_binary(struct mpd_async *async, const struct timeval *tv0, struct mpd_binary *buffer, size_t length)
 {
 	struct timeval tv, *tvp;
 

--- a/src/sync.c
+++ b/src/sync.c
@@ -26,12 +26,15 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "binary.h"
 #include "sync.h"
 #include "socket.h"
+#include "binary.h"
+
 #include <mpd/async.h>
+
 #include <assert.h>
-#include <stddef.h>
+#include <stdlib.h>
+#include <stdio.h>
 
 #ifndef _WIN32
 #include <sys/select.h>

--- a/src/sync.c
+++ b/src/sync.c
@@ -26,11 +26,12 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <mpd/binary.h>
+#include "binary.h"
 #include "sync.h"
 #include "socket.h"
 #include <mpd/async.h>
 #include <assert.h>
+#include <stddef.h>
 
 #ifndef _WIN32
 #include <sys/select.h>

--- a/src/sync.c
+++ b/src/sync.c
@@ -29,10 +29,9 @@
 #include "sync.h"
 #include "socket.h"
 #include <mpd/async.h>
-
+#include <mpd/binary.h>
 #include <assert.h>
-#include <stdlib.h>
-#include <stdio.h>
+
 #ifndef _WIN32
 #include <sys/select.h>
 #endif
@@ -178,5 +177,29 @@ mpd_sync_recv_line(struct mpd_async *async, const struct timeval *tv0)
 
 		if (!mpd_sync_io(async, tvp))
 			return NULL;
+	}
+}
+
+struct mpd_binary
+mpd_sync_recv_binary(struct mpd_async *async, const struct timeval *tv0, const unsigned binary)
+{
+	struct timeval tv, *tvp;
+	struct mpd_binary data;
+	data.size = 0;
+	data.data = NULL;
+
+	if (tv0 != NULL) {
+		tv = *tv0;
+		tvp = &tv;
+	} else
+		tvp = NULL;
+
+	while (true) {
+		data = mpd_async_recv_binary(async, binary);
+		if (data.data != NULL)
+			return data;
+
+		if (!mpd_sync_io(async, tvp))
+			return data;
 	}
 }

--- a/src/sync.h
+++ b/src/sync.h
@@ -71,7 +71,10 @@ mpd_sync_flush(struct mpd_async *async, const struct timeval *tv);
 char *
 mpd_sync_recv_line(struct mpd_async *async, const struct timeval *tv);
 
-struct mpd_binary
-mpd_sync_recv_binary(struct mpd_async *async, const struct timeval *tv, const unsigned binary);
+/**
+ * Synchronous wrapper for mpd_async_recv_binary().
+ */
+struct mpd_binary *
+mpd_sync_recv_binary(struct mpd_async *async, const struct timeval *tv, struct mpd_binary *buffer, const unsigned length);
 
 #endif

--- a/src/sync.h
+++ b/src/sync.h
@@ -1,5 +1,5 @@
 /* libmpdclient
-   (c) 2003-2018 The Music Player Daemon Project
+   (c) 2003-2019 The Music Player Daemon Project
    This project's homepage is: http://www.musicpd.org
 
    Redistribution and use in source and binary forms, with or without
@@ -40,6 +40,7 @@
 
 #include <stdbool.h>
 #include <stdarg.h>
+#include <stddef.h>
 
 struct timeval;
 struct mpd_async;
@@ -75,6 +76,6 @@ mpd_sync_recv_line(struct mpd_async *async, const struct timeval *tv);
  * Synchronous wrapper for mpd_async_recv_binary().
  */
 struct mpd_binary *
-mpd_sync_recv_binary(struct mpd_async *async, const struct timeval *tv, struct mpd_binary *buffer, const unsigned length);
+mpd_sync_recv_binary(struct mpd_async *async, const struct timeval *tv, struct mpd_binary *buffer, size_t length);
 
 #endif


### PR DESCRIPTION
This pull requests adds following functions:
mpd_async_recv_binary -> works like mpd_async_recv_line
mpd_sync_recv_binary -> works like mpd_sync_recv_line
mpd_recv_binary -> works like mpd_recv_pair