### PR TITLE
async: clarify mpd_async_send_command description

### DIFF
--- a/include/mpd/async.h
+++ b/include/mpd/async.h
@@ -178,8 +178,9 @@ mpd_async_io(struct mpd_async *async, enum mpd_async_event events);
  * @param async the connection
  * @param command the command name, followed by arguments, terminated by
  * NULL
- * @param args the argument list
- * @return true on success, false if the buffer is full
+ * @param args the list of 'const char *' arguments
+ * @return true on success, false if the buffer is full or an error has
+ * previously occurred
  */
 bool
 mpd_async_send_command_v(struct mpd_async *async, const char *command,
@@ -190,8 +191,9 @@ mpd_async_send_command_v(struct mpd_async *async, const char *command,
  *
  * @param async the connection
  * @param command the command name, followed by arguments, terminated by
- * NULL
- * @return true on success, false if the buffer is full
+ * NULL. The arguments should be of type 'const char *'
+ * @return true on success, false if the buffer is full or an error has
+ * previously occurred
  */
 mpd_sentinel
 bool


### PR DESCRIPTION
Hello,
this commit clarifies two things about mpd_async_send_command: (i) the args list expects only one datatype (const char *) and (ii) the function can fail due to a previous async operation that may be unrelated to the buffer status.