### PR TITLE
man: create man pages for async functions

### DIFF
--- a/man/mpd_async_events.3
+++ b/man/mpd_async_events.3
@@ -1,0 +1,79 @@
+.TH MPD_ASYNC_EVENTS 3 2019
+.SH NAME
+mpd_async_events, mpd_async_io \- async I/O operations for mpd
+.SH SYNOPSIS
+.B #include <mpd/async.h>
+.PP
+.BI "enum mpd_async_event mpd_async_events(const struct mpd_async *" async );
+.PP
+.BI "bool mpd_async_io(struct mpd_async *" "async" ", enum mpd_async_event"
+.BI "" events );
+.SH DESCRIPTION
+The
+.BR mpd_async_events ()
+creates the bitmask of events for the function
+.BR mpd_async_io ().
+.PP
+The
+.BR mpd_async_io ()
+will attempt to perform I/O operations on the
+.IR mpd_async
+object.
+.PP
+The user should first use the function
+.BR poll ()
+then use the functions
+.BR mpd_async_events ()
+and
+.BR mpd_async_io ()
+after 
+.BR poll () 
+returns so that libmpdclient can perform I/O operations.
+.SS The mpd_async_event enum
+The
+.I mpd_async_event
+enum is defined as follows:
+.PP
+.in +4n
+.EX
+enum mpd_async_event {
+	/** ready to read from the file descriptor */
+	MPD_ASYNC_EVENT_READ = 1,
+
+	/** ready to write to the file descriptor */
+	MPD_ASYNC_EVENT_WRITE = 2,
+
+	/** hangup detected */
+	MPD_ASYNC_EVENT_HUP = 4,
+
+	/** I/O error */
+	MPD_ASYNC_EVENT_ERROR = 8,
+};
+.EE
+.in
+.PP
+.SH RETURN VALUE
+The function
+.BR mpd_async_events ()
+returns a
+.IR mpd_async_event
+object.
+.PP
+The function
+.BR mpd_async_io ()
+returns false if the connection was closed due to an error; otherwise, true is
+returned.
+.SH ERRORS
+No errors are defined for
+.BR mpd_async_events () .
+.PP
+If
+.BR mpd_async_io () 
+returned false, the user should use one of the error functions of libmpdclient.
+.SH SEE ALSO
+.BR mpd_async_get_error (3),
+.BR mpd_async_get_error_message (3),
+.BR mpd_async_get_system_error (3),
+.BR mpd_async_send_command_v (3),
+.BR mpd_async_send_command (3),
+.BR mpd_async_recv_line (3)

--- a/man/mpd_async_free.3
+++ b/man/mpd_async_free.3
@@ -1,0 +1,20 @@
+.TH MPD_ASYNC_FREE 3 2019
+.SH NAME
+mpd_async_free \- closes the asynchronous MPD connection
+.SH SYNOPSIS
+.nf
+.B #include <mpd/async.h>
+.PP
+.BI "void mpd_async_free(struct mpd_async *" async );
+.fi
+.SH DESCRIPTION
+The
+.BR mpd_async_free ()
+closes the socket and frees the memory allocated previously with
+.BR mpd_async_new (3).
+.SH RETURN VALUE
+The
+.BR mpd_async_free ()
+function returns no value.
+.SH SEE ALSO
+.BR mpd_async_new (3)

--- a/man/mpd_async_get_error.3
+++ b/man/mpd_async_get_error.3
@@ -1,0 +1,81 @@
+.TH MPD_ASYNC_GET_ERROR 3 2019
+.SH NAME
+mpd_async_get_error \- returns the error code
+.SH SYNOPSIS
+.nf
+.B #include <mpd/async.h>
+.PP
+.BI "enum mpd_error mpd_async_get_error(const struct mpd_async *" async );
+.fi
+.SH DESCRIPTION
+The
+.BR mpd_async_get_error ()
+returns information about the last error encountered. If no error has occured,
+it returns
+.I MPD_ERROR_SUCCESS.
+.SS The mpd_error enum
+The
+.BR mpd_async_get_error ()
+function returns a
+.I mpd_error
+enum, which has one of the following values:
+.PP
+.in +4n
+.EX
+enum mpd_error {
+	/** no error */
+	MPD_ERROR_SUCCESS = 0,
+
+	/** out of memory */
+	MPD_ERROR_OOM,
+
+	/** a function was called with an unrecognized or invalid
+	    argument */
+	MPD_ERROR_ARGUMENT,
+
+	/** a function was called which is not available in the
+	    current state of libmpdclient */
+	MPD_ERROR_STATE,
+
+	/** timeout trying to talk to mpd */
+	MPD_ERROR_TIMEOUT,
+
+	/** system error */
+	MPD_ERROR_SYSTEM,
+
+	/** unknown host */
+	MPD_ERROR_RESOLVER,
+
+	/** malformed response received from MPD */
+	MPD_ERROR_MALFORMED,
+
+	/** connection closed by mpd */
+	MPD_ERROR_CLOSED,
+
+	/**
+	 * The server has returned an error code, which can be queried
+	 * with mpd_connection_get_server_error().
+	 */
+	MPD_ERROR_SERVER,
+};
+.EE
+.in
+.PP
+.SH RETURN VALUE
+The
+.BR mpd_async_get_new ()
+function returns a 
+.I mpd_error
+object.
+.SH ERRORS
+No errors are defined.
+.SH SEE ALSO
+.BR mpd_async_new (3),
+.BR mpd_async_get_error_message (3),
+.BR mpd_async_get_system_error (3),
+.BR mpd_async_keepalive (3),
+.BR mpd_async_events (3),
+.BR mpd_async_io (3),
+.BR mpd_async_send_command_v (3),
+.BR mpd_async_send_command (3),
+.BR mpd_async_recv_line (3)

--- a/man/mpd_async_get_error_message.3
+++ b/man/mpd_async_get_error_message.3
@@ -1,0 +1,94 @@
+.TH MPD_ASYNC_GET_ERROR_MESSAGE 3 2019
+.SH NAME
+mpd_async_get_error_message \- returns the human-readable error message
+.SH SYNOPSIS
+.nf
+.B #include <mpd/async.h>
+.PP
+.BI "const char *mpd_async_get_error_message(const struct mpd_async *" async );
+.fi
+.SH DESCRIPTION
+The
+.BR mpd_async_get_error_message ()
+returns the human-readable error message for the last error encountered. The
+message returned by this function is optional, and may be NULL.
+.PP
+.BR mpd_async_get_error_message ()
+should only be used if the last libmpdclient function returned an
+error. The operation status can be checked by calling the function
+.BR mpd_async_get_error ().
+.PP
+For the error type
+.IR "MPD_ERROR_SERVER" , 
+the error message is encoded in UTF-8. Additionally,
+.I MPD_ERROR_SYSTEM
+obtains its error message from the operating system, and thus the locale's
+character set is used. Keep that in mind when you print error messages.
+
+
+.SS The mpd_error enum
+The
+.BR mpd_async_get_error_message ()
+uses internally the
+.I mpd_error
+enum, which has one of the following values:
+.PP
+.in +4n
+.EX
+enum mpd_error {
+	/** no error */
+	MPD_ERROR_SUCCESS = 0,
+
+	/** out of memory */
+	MPD_ERROR_OOM,
+
+	/** a function was called with an unrecognized or invalid
+	    argument */
+	MPD_ERROR_ARGUMENT,
+
+	/** a function was called which is not available in the
+	    current state of libmpdclient */
+	MPD_ERROR_STATE,
+
+	/** timeout trying to talk to mpd */
+	MPD_ERROR_TIMEOUT,
+
+	/** system error */
+	MPD_ERROR_SYSTEM,
+
+	/** unknown host */
+	MPD_ERROR_RESOLVER,
+
+	/** malformed response received from MPD */
+	MPD_ERROR_MALFORMED,
+
+	/** connection closed by mpd */
+	MPD_ERROR_CLOSED,
+
+	/**
+	 * The server has returned an error code, which can be queried
+	 * with mpd_connection_get_server_error().
+	 */
+	MPD_ERROR_SERVER,
+};
+.EE
+.in
+.PP
+The user can access the value by calling
+.BR mpd_async_get_error ().
+.SH RETURN VALUE
+The function returns the null-terminated string as a
+.I const char *
+or NULL.
+.SH ERRORS
+No errors are defined.
+.SH SEE ALSO
+.BR mpd_async_new (3),
+.BR mpd_async_get_error (3),
+.BR mpd_async_get_system_error (3),
+.BR mpd_async_keepalive (3),
+.BR mpd_async_events (3),
+.BR mpd_async_io (3),
+.BR mpd_async_send_command_v (3),
+.BR mpd_async_send_command (3),
+.BR mpd_async_recv_line (3)

--- a/man/mpd_async_get_fd.3
+++ b/man/mpd_async_get_fd.3
@@ -1,0 +1,40 @@
+.TH MPD_ASYNC_GET_FD 3 2019
+.SH NAME
+mpd_async_get_fd \- returns the file descriptor to be polled by the caller
+.SH SYNOPSIS
+.nf
+.B #include <mpd/async.h>
+.PP
+.BI "int mpd_async_get_fd(const struct mpd_async *" async );
+.fi
+.SH DESCRIPTION
+The
+.BR mpd_async_get_fd ()
+returns the file descriptor which should be polled by the caller.
+.PP
+The user must not use the file descriptor for anything except polling.
+.PP
+The file descriptor never changes during the lifetime of the caller
+.IR mpd_async
+object.
+.SH RETURN VALUE
+The function returns the file descriptor
+.IR fd
+of the
+.IR mpd_async
+object.
+.PP
+The
+.IR fd
+was previously received by the function
+.BR mpd_async_new ().
+.SH ERRORS
+No errors are defined.
+.SH SEE ALSO
+.BR mpd_async_new (3),
+.BR mpd_async_keepalive (3),
+.BR mpd_async_events (3),
+.BR mpd_async_io (3),
+.BR mpd_async_send_command_v (3),
+.BR mpd_async_send_command (3),
+.BR mpd_async_recv_line (3)

--- a/man/mpd_async_get_system_error.3
+++ b/man/mpd_async_get_system_error.3
@@ -1,0 +1,40 @@
+.TH MPD_ASYNC_GET_SYSTEM_ERROR 3 2019
+.SH NAME
+mpd_async_get_system_error \- returns the error code from the operating system
+.SH SYNOPSIS
+.nf
+.B #include <mpd/async.h>
+.PP
+.BI "int mpd_async_get_system_error(const struct mpd_async *" async );
+.fi
+.SH DESCRIPTION
+The
+.BR mpd_async_get_system_error ()
+returns the error code from the operating system; on most operating systems,
+this is the
+.IR errno
+value.
+.PP
+Calling this function is only valid if
+.BR mpd_async_get_error ()
+returns
+.IR "MPD_ERROR_SYSTEM" .
+.SH RETURN VALUE
+The function returns the
+.IR errno
+value or the equivalent for the operating system.
+.PP
+This function may return 0 if the operating system did not specify an error
+code.
+.SH ERRORS
+No errors are defined.
+.SH SEE ALSO
+.BR mpd_async_new (3),
+.BR mpd_async_get_error (3),
+.BR mpd_async_get_error_message (3),
+.BR mpd_async_keepalive (3),
+.BR mpd_async_events (3),
+.BR mpd_async_io (3),
+.BR mpd_async_send_command_v (3),
+.BR mpd_async_send_command (3),
+.BR mpd_async_recv_line (3)

--- a/man/mpd_async_io.3
+++ b/man/mpd_async_io.3
@@ -1,0 +1,1 @@
+.so mpd_async_events.3

--- a/man/mpd_async_new.3
+++ b/man/mpd_async_new.3
@@ -1,0 +1,38 @@
+.TH MPD_ASYNC_NEW 3 2019
+.SH NAME
+mpd_async_new \- creates a new asynchronous MPD connection
+.SH SYNOPSIS
+.nf
+.B #include <mpd/async.h>
+.PP
+.BI "struct mpd_async *mpd_async_new(int "fd );
+.fi
+.SH DESCRIPTION
+The
+.BR mpd_async_new ()
+returns a pointer to the asynchronous MPD connection, based on the stream socket 
+.IR fd
+connected with MPD. Memory for the opaque object
+.IR "struct mpd_async"
+is obtained with
+.BR malloc (3)
+and must be freed with
+.BR mpd_async_free ().
+.SH RETURN VALUE
+The
+.BR mpd_async_new ()
+function returns a pointer to the opaque object
+.IR "struct mpd_async".
+It returns NULL if insufficient memory was available,
+with
+.I errno
+set appropriately to indicate the cause of the error.
+.SH ERRORS
+.BR ENOMEM
+Out of memory.
+.SH SEE ALSO
+.BR mpd_async_free (3),
+.BR mpd_async_get_error (3),
+.BR mpd_async_get_error_message (3),
+.BR mpd_async_get_system_error (3),
+.BR mpd_async_get_fd (3)

--- a/man/mpd_async_recv_line.3
+++ b/man/mpd_async_recv_line.3
@@ -1,0 +1,30 @@
+.TH MPD_ASYNC_RECV_LINE 3 2019
+.SH NAME
+mpd_async_recv_line \- receives a line from the input buffer
+.SH SYNOPSIS
+.nf
+.B #include <mpd/async.h>
+.PP
+.BI "char *mpd_async_recv_line(struct mpd_async *" async );
+.fi
+.SH DESCRIPTION
+The functions
+.BR mpd_async_recv_line ()
+receives a line from the input buffer. The line is null-terminated without the
+newline character at the end.
+.PP
+The line is returned as a
+.IR "char *"
+and is only valid until the next async function is called.
+
+.SH RETURN VALUE
+The function returns a line on success or NULL on error.
+.SH ERRORS
+If
+.BR mpd_async_recv_line ()
+returns NULL, the user should use one of the error functions of libmpdclient.
+.SH SEE ALSO
+.BR mpd_async_get_error (3),
+.BR mpd_async_get_error_message (3),
+.BR mpd_async_get_system_error (3),
+.BR mpd_async_io (3)

--- a/man/mpd_async_send_command.3
+++ b/man/mpd_async_send_command.3
@@ -1,0 +1,1 @@
+.so mpd_async_send_command_v.3

--- a/man/mpd_async_send_command_v.3
+++ b/man/mpd_async_send_command_v.3
@@ -1,0 +1,36 @@
+.TH MPD_ASYNC_EVENTS 3 2019
+.SH NAME
+mpd_async_send_command, mpd_async_send_command_v \- appends a command to the
+output buffer
+.SH SYNOPSIS
+.B #include <mpd/async.h>
+.PP
+.BI "bool mpd_async_send_command(struct mpd_async *" "async" ","
+.BI "const char *" "command" ", ...);"
+.PP
+.BI "bool mpd_async_send_command_v(struct mpd_async *" async ","
+.BI "const char *" command ", va_list " args );
+.SH DESCRIPTION
+The functions
+.BR mpd_async_send_command ()
+and
+.BR mpd_async_send_command_v ()
+append a command to the output buffer. Both functions receive the command
+followed by arguments that must be terminated by NULL. The arguments are
+expected to be of type 
+.IR "const char *".
+
+.SH RETURN VALUE
+The functions return true on success or false if either the buffer is full or
+an error has occured previous to the function call.
+.SH ERRORS
+If
+.BR mpd_async_send_command ()
+or
+.BR mpd_async_send_command_v ()
+returned false, the user should use one of the error functions of libmpdclient.
+.SH SEE ALSO
+.BR mpd_async_get_error (3),
+.BR mpd_async_get_error_message (3),
+.BR mpd_async_get_system_error (3),
+.BR mpd_async_recv_line (3)

--- a/man/mpd_async_set_keepalive.3
+++ b/man/mpd_async_set_keepalive.3
@@ -1,0 +1,36 @@
+.TH MPD_ASYNC_SET_KEEPALIVE 3 2019
+.SH NAME
+mpd_async_set_keepalive \- enables/disables TCP keepalives
+.SH SYNOPSIS
+.nf
+.B #include <mpd/async.h>
+.PP
+.BI "void mpd_async_set_keepalive(struct mpd_async *" async ", bool " keepalive );
+.fi
+.SH DESCRIPTION
+The
+.BR mpd_async_set_keepalive ()
+enables or disables the use of TCP keepalives. They may be required for
+long-idled connections to persist on some networks that would otherwise
+terminate inactive TCP sessions.
+.PP
+The default behavior is to not use TCP keepalives.
+.SH ERRORS
+The 
+.BR mpd_async_set_keepalive ()
+function uses internally the function
+.BR "setsockopt()" ;
+errors can be checked only if
+.IR errno
+has been set to zero before calling
+.BR mpd_async_set_keepalives (),
+and 
+.IR errno 
+is rechecked after the call.
+.SH HISTORY
+The function
+.BR mpd_async_set_keepalive ()
+first appeared in libmpdclient 2.10.
+.SH SEE ALSO
+.BR mpd_async_get_system_error (3)
+.BR mpd_async_io (3),

--- a/meson.build
+++ b/meson.build
@@ -209,6 +209,19 @@ install_headers(
   join_paths(meson.build_root(), 'version.h'),
   subdir: 'mpd')
 
+install_man('man/mpd_async_events.3',
+	'man/mpd_async_free.3',
+	'man/mpd_async_get_error.3',
+	'man/mpd_async_get_error_message.3',
+	'man/mpd_async_get_fd.3',
+	'man/mpd_async_get_system_error.3',
+	'man/mpd_async_io.3',
+	'man/mpd_async_new.3',
+	'man/mpd_async_recv_line.3',
+	'man/mpd_async_send_command.3',
+	'man/mpd_async_send_command_v.3',
+	'man/mpd_async_set_keepalive.3')
+
 docdir = join_paths(get_option('datadir'), 'doc', meson.project_name())
 install_data('AUTHORS', 'COPYING', 'NEWS', 'README.rst',
   install_dir: docdir)


### PR DESCRIPTION
Hello!
I would like to create man pages for the libmpdclient API. 
This commit creates pages for the async operations only.
Personally, i think its a great feature for vi developers like myself (one keystroke to go to the man page)

let me know if this interests the developers.

best regards

PS: since meson 0.49, man pages are not compressed implicitly as distributions use different compression algorithms. Therefore, the compression is left as a responsability for the distro/user.