### PR TITLE
async: unveil status of mpd_async_set_keepalive operation

### DIFF
--- a/include/mpd/async.h
+++ b/include/mpd/async.h
@@ -148,10 +148,11 @@ mpd_async_get_fd(const struct mpd_async *async);
  *
  * @param async the #mpd_async object
  * @param keepalive whether TCP keepalives should be enabled
+ * @return true on success, false if setsockopt failed
  *
  * @since libmpdclient 2.10
  */
-void
+bool
 mpd_async_set_keepalive(struct mpd_async *async,
 			bool keepalive);
 

--- a/src/async.c
+++ b/src/async.c
@@ -137,14 +137,14 @@ mpd_async_get_fd(const struct mpd_async *async)
 	return async->fd;
 }
 
-void
+bool
 mpd_async_set_keepalive(struct mpd_async *async,
 			bool keepalive)
 {
 	assert(async != NULL);
 	assert(async->fd != MPD_INVALID_SOCKET);
 
-	mpd_socket_keepalive(async->fd, keepalive);
+	return mpd_socket_keepalive(async->fd, keepalive) == 0;
 }
 
 enum mpd_async_event

--- a/src/socket.c
+++ b/src/socket.c
@@ -199,12 +199,12 @@ mpd_socket_close(mpd_socket_t fd)
 #endif
 }
 
-void
+int
 mpd_socket_keepalive(mpd_socket_t fd, bool keepalive)
 {
 	int keepalive_i = keepalive;
 
 
-	(void) setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE,
+	return setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE,
 			  (const char *) &keepalive_i, sizeof keepalive_i);
 }

--- a/src/socket.h
+++ b/src/socket.h
@@ -96,7 +96,7 @@ mpd_socket_close(mpd_socket_t fd);
 /**
  * Sets (or unsets) keepalive on a socket descriptor.
  */
-void
+int
 mpd_socket_keepalive(mpd_socket_t fd, bool keepalive);
 
 #endif


### PR DESCRIPTION
Provide the result of setsockopt() for the caller of
mpd_async_set_keepalive()