### PR TITLE
connection: unveil status of mpd_connection_set_keepalive operation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@ libmpdclient 2.17 (not yet released)
 * support MPD protocol 0.22
   - "getfingerprint"
 * mpd_async_set_keepalive() returns bool
+* mpd_connection_set_keepalive() returns bool
 * fix build failure on Haiku
 
 libmpdclient 2.16 (2018/10/09)

--- a/include/mpd/connection.h
+++ b/include/mpd/connection.h
@@ -147,10 +147,11 @@ mpd_connection_get_settings(const struct mpd_connection *connection);
  *
  * @param connection the connection to MPD
  * @param keepalive whether TCP keepalives should be enabled
+ * @return true on success, false if setsockopt failed
  *
  * @since libmpdclient 2.10
  */
-void
+bool
 mpd_connection_set_keepalive(struct mpd_connection *connection,
 			     bool keepalive);
 

--- a/src/connection.c
+++ b/src/connection.c
@@ -241,13 +241,13 @@ void mpd_connection_free(struct mpd_connection *connection)
 	free(connection);
 }
 
-void
+bool
 mpd_connection_set_keepalive(struct mpd_connection *connection,
 			     bool keepalive)
 {
 	assert(connection != NULL);
 
-	mpd_async_set_keepalive(connection->async, keepalive);
+	return mpd_async_set_keepalive(connection->async, keepalive);
 }
 
 const struct mpd_settings *


### PR DESCRIPTION
Provide the result of setsockopt() for the caller of
mpd_connection_set_keepalive()
---
update mpd_connection_set_keepalive() since commit f7592ba8130c9c3f1f654b3bd2f9381791679036 changed mpd_async_set_keepalive() from void to bool