### PR TITLE
news: add new tag types supported by libmpdclient

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@ libmpdclient 2.17 (not yet released)
 * search: add mpd_search_add_db_songs_to_playlist()
 * support MPD protocol 0.22
   - "getfingerprint"
+* support tag "MPD_TAG_LABEL" and "MPD_TAG_MUSICBRAINZ_WORKID"
 * mpd_async_set_keepalive() returns bool
 * fix build failure on Haiku
 


### PR DESCRIPTION
commit 1f57d2206fd7a9bd7824b1d5151511eacf7dce26
added support for MPD_TAG_LABEL and MPD_MUSICBRAINZ_WORKID
---
i forgot to change the NEWS file for commit 1f57d2206fd7a9bd7824b1d5151511eacf7dce26