### PR TITLE
Documentation updates for async, idle, list, mount, output and player subsystems

### DIFF
--- a/include/mpd/async.h
+++ b/include/mpd/async.h
@@ -205,6 +205,8 @@ mpd_async_send_command(struct mpd_async *async, const char *command, ...);
  * null-terminated, without the newline character.  The pointer is
  * only valid until the next async function is called.
  *
+ * You can use mpd_parser_new() and mpd_parser_feed() for parsing the line.
+ *
  * @param async the connection
  * @return a line on success, NULL otherwise
  */

--- a/include/mpd/idle.h
+++ b/include/mpd/idle.h
@@ -53,7 +53,7 @@ struct mpd_connection;
  * #MPD_IDLE_SUBSCRIPTION and #MPD_IDLE_MESSAGE.
  */
 enum mpd_idle {
-	/** song database has been updated*/
+	/** song database has been updated */
 	MPD_IDLE_DATABASE = 0x1,
 
 	/** a stored playlist has been modified, created, deleted or
@@ -120,6 +120,9 @@ mpd_idle_name_parse(const char *name);
  * occurred.  Call mpd_send_noidle() to abort the idle mode, or
  * mpd_recv_idle() to read the event mask (or synchronously wait for
  * events).
+ *
+ * @param connection the connection to MPD
+ * @return true on success
  */
 bool
 mpd_send_idle(struct mpd_connection *connection);
@@ -129,7 +132,7 @@ mpd_send_idle(struct mpd_connection *connection);
  *
  * @param connection the connection to MPD
  * @param mask a bit mask of idle events; must not be 0
- * @return a positive job id on success, 0 on error
+ * @return true on success
  */
 bool
 mpd_send_idle_mask(struct mpd_connection *connection, enum mpd_idle mask);
@@ -138,6 +141,9 @@ mpd_send_idle_mask(struct mpd_connection *connection, enum mpd_idle mask);
  * Tells MPD to leave the "idle" mode.  MPD will then respond with a
  * list of events which have occurred (which may be empty).  Call
  * mpd_recv_idle() after that.
+ *
+ * @param connection the connection to MPD
+ * @return true on success
  */
 bool
 mpd_send_noidle(struct mpd_connection *connection);
@@ -146,6 +152,7 @@ mpd_send_noidle(struct mpd_connection *connection);
  * Parses a "changed" pair, which is part of MPD's response to the
  * "idle" command.
  *
+ * @param pair the "changed" pair
  * @return an idle code, or 0 if the pair was not understood
  */
 mpd_pure

--- a/include/mpd/idle.h
+++ b/include/mpd/idle.h
@@ -164,7 +164,7 @@ mpd_idle_parse_pair(const struct mpd_pair *pair);
  * bit mask.
  *
  * @param connection the connection to MPD
- * @param disable_timeout if true, then libmpdclients temporarily
+ * @param disable_timeout if true, then libmpdclient temporarily
  * disables the configured timeout (see mpd_connection_set_timeout()):
  * this function blocks forever, until either MPD sends a response, or
  * an error occurs.

--- a/include/mpd/mount.h
+++ b/include/mpd/mount.h
@@ -80,7 +80,7 @@ bool
 mpd_mount_feed(struct mpd_mount *mnt, const struct mpd_pair *pair);
 
 /**
- * Frees a mpd_mount object returned from mpd_recv_mount().
+ * Frees a mpd_mount object returned from mpd_recv_mount() or mpd_mount_begin().
  *
  * @since libmpdclient 2.16
  */

--- a/include/mpd/output.h
+++ b/include/mpd/output.h
@@ -80,7 +80,8 @@ bool
 mpd_output_feed(struct mpd_output *output, const struct mpd_pair *pair);
 
 /**
- * Frees a mpd_output object returned from mpd_recv_output().
+ * Frees a mpd_output object returned from mpd_recv_output() or
+ * mpd_output_begin().
  */
 void
 mpd_output_free(struct mpd_output *output);
@@ -153,8 +154,8 @@ const struct mpd_pair *
 mpd_output_next_attribute(struct mpd_output *output);
 
 /**
- * Sends the "outputs" command to MPD.  Call mpd_recv_output() to
- * read the response.
+ * Sends the "outputs" command to MPD: fetch information about all outputs.
+ * Call mpd_recv_output() to read the response.
  *
  * @param connection A valid and connected mpd_connection.
  * @return true on success
@@ -244,7 +245,8 @@ bool
 mpd_run_toggle_output(struct mpd_connection *connection, unsigned output_id);
 
 /**
- * Sends the "outputset" command to MPD.
+ * Sends the "outputset" command to MPD: set a runtime attribute for the
+ * specified output_id.
  *
  * @param connection a valid and connected mpd_connection
  * @param output_id an identifier for the output device (see

--- a/include/mpd/player.h
+++ b/include/mpd/player.h
@@ -50,13 +50,17 @@ extern "C" {
 
 /**
  * Fetches the currently selected song (the song referenced by
- * status->song and status->songid).
+ * mpd_status_get_song_id()).
+ * Call mpd_recv_song() to receive the response.
+ *
+ * @param connection the connection to MPD
+ * @return true on success, false on error
  */
 bool
 mpd_send_current_song(struct mpd_connection *connection);
 
 /**
- * Shortcut for mpd_send_currentsong() and mpd_recv_song().
+ * Shortcut for mpd_send_current_song() and mpd_recv_song().
  *
  * @param connection the connection to MPD
  * @return the current song, or NULL on error or if there is no
@@ -70,23 +74,37 @@ mpd_run_current_song(struct mpd_connection *connection);
  * Starts playing the current song from the beginning.
  *
  * @param connection the connection to MPD
+ * @return true on success, false on error
  */
 bool
 mpd_send_play(struct mpd_connection *connection);
 
+/**
+ * Shortcut for mpd_send_play() and mpd_response_finish().
+ *
+ * @param connection the connection to MPD
+ * @return true on success, false on error
+ */
 bool
 mpd_run_play(struct mpd_connection *connection);
 
 /**
  * Starts playing the specified song from the beginning.
  *
- * @param song_pos the position of the song in the queue
  * @param connection the connection to MPD
+ * @param song_pos the position of the song in the queue
  * @return true on success, false on error
  */
 bool
 mpd_send_play_pos(struct mpd_connection *connection, unsigned song_pos);
 
+/**
+ * Shortcut for mpd_send_play() and mpd_response_finish().
+ *
+ * @param connection the connection to MPD
+ * @param song_pos the position of the song in the queue
+ * @return true on success, false on error
+ */
 bool
 mpd_run_play_pos(struct mpd_connection *connection, unsigned song_pos);
 
@@ -100,46 +118,114 @@ mpd_run_play_pos(struct mpd_connection *connection, unsigned song_pos);
 bool
 mpd_send_play_id(struct mpd_connection *connection, unsigned id);
 
+/**
+ * Shortcut for mpd_send_play_id() and mpd_response_finish().
+ *
+ * @param connection the connection to MPD
+ * @param song_id the id of the song
+ * @return true on success, false on error
+ */
 bool
 mpd_run_play_id(struct mpd_connection *connection, unsigned song_id);
 
+/**
+ * Stops playing the current song.
+ *
+ * @param connection the connection to MPD
+ * @return true on success, false on error
+ */
 bool
 mpd_send_stop(struct mpd_connection *connection);
 
+/**
+ * Shortcut for mpd_send_stop() and mpd_response_finish().
+ *
+ * @param connection the connection to MPD
+ * @return true on success, false on error
+ */
 bool
 mpd_run_stop(struct mpd_connection *connection);
 
 /**
+ * This function uses a deprecated feature of MPD, you should avoid it.
+ *
  * Toggles the pause mode by sending "pause" without arguments.
  *
  * @param connection the connection to MPD
+ * @return true on success, false on error
  */
 bool
 mpd_send_toggle_pause(struct mpd_connection *connection);
 
+/**
+ * This function uses a deprecated feature of MPD, you should avoid it.
+ * Shortcut for mpd_send_toggle_pause() and mpd_response_finish().
+ *
+ * @param connection the connection to MPD
+ * @return true on success, false on error
+ */
 bool
 mpd_run_toggle_pause(struct mpd_connection *connection);
 
+/**
+ * Pauses/Resumes playing the current song.
+ * If mode is true, MPD pauses the song; otherwise, MPD resumes the song.
+ *
+ * @param connection the connection to MPD
+ * @param mode if true: pause, if false: resume
+ * @return true on success, false on error
+ */
 bool
 mpd_send_pause(struct mpd_connection *connection, bool mode);
 
+/**
+ * Shortcut for mpd_send_pause() and mpd_response_finish().
+ *
+ * @param connection the connection to MPD
+ * @param mode if true: pause, if false: resume
+ * @return true on success, false on error
+ */
 bool
 mpd_run_pause(struct mpd_connection *connection, bool mode);
 
+/**
+ * Play the next song in the playlist.
+ *
+ * @param connection the connection to MPD
+ * @return true on success, false on error
+ */
 bool
 mpd_send_next(struct mpd_connection *connection);
 
+/**
+ * Shortcut for mpd_send_next() and mpd_response_finish().
+ *
+ * @param connection the connection to MPD
+ * @return true on success, false on error
+ */
 bool
 mpd_run_next(struct mpd_connection *connection);
 
+/**
+ * Play the previous song in the playlist.
+ *
+ * @param connection the connection to MPD
+ * @return true on success, false on error
+ */
 bool
 mpd_send_previous(struct mpd_connection *connection);
 
+/**
+ * Shortcut for mpd_send_previous() and mpd_response_finish().
+ *
+ * @param connection the connection to MPD
+ * @return true on success, false on error
+ */
 bool
 mpd_run_previous(struct mpd_connection *connection);
 
 /**
- * Seeks the specified song.
+ * Seeks to the position t (in seconds) of position song_pos in the playlist.
  *
  * @param connection the connection to MPD
  * @param song_pos the position of the song in the queue
@@ -150,12 +236,20 @@ bool
 mpd_send_seek_pos(struct mpd_connection *connection,
 		  unsigned song_pos, unsigned t);
 
+/**
+ * Shortcut for mpd_send_seek_pos() and mpd_response_finish().
+ *
+ * @param connection the connection to MPD
+ * @param song_pos the position of the song in the queue
+ * @param t the position within the song, in seconds
+ * @return true on success, false on error
+ */
 bool
 mpd_run_seek_pos(struct mpd_connection *connection,
 		 unsigned song_pos, unsigned t);
 
 /**
- * Seeks the specified song.
+ * Seeks to the position t (in seconds) of song id song_id.
  *
  * @param connection the connection to MPD
  * @param id the id of the song
@@ -165,22 +259,38 @@ mpd_run_seek_pos(struct mpd_connection *connection,
 bool
 mpd_send_seek_id(struct mpd_connection *connection, unsigned id, unsigned t);
 
+/**
+ * Shortcut for mpd_send_seek_id() and mpd_response_finish().
+ *
+ * @param connection the connection to MPD
+ * @param song_id the id of the song
+ * @param t the position within the song, in seconds
+ * @return true on success, false on error
+ */
 bool
 mpd_run_seek_id(struct mpd_connection *connection,
 		unsigned song_id, unsigned t);
 
 /**
- * Seeks the specified song (with floating point time).
+ * Seeks to the position t (in seconds; fractions allowed) of song id song_id.
  *
  * @param connection the connection to MPD
  * @param id the id of the song
- * @param t the position within the song, in seconds
+ * @param t the position within the song, in seconds (fractions allowed)
  * @return true on success, false on error
  */
 bool
 mpd_send_seek_id_float(struct mpd_connection *connection,
 		       unsigned id, float t);
 
+/**
+ * Shortcut for mpd_send_seek_id_float() and mpd_response_finish().
+ *
+ * @param connection the connection to MPD
+ * @param song_id the id of the song
+ * @param t the position within the song, in seconds (fractions allowed)
+ * @return true on success, false on error
+ */
 bool
 mpd_run_seek_id_float(struct mpd_connection *connection,
 		      unsigned song_id, float t);
@@ -199,71 +309,212 @@ bool
 mpd_send_seek_current(struct mpd_connection *connection,
 		      float t, bool relative);
 
+/**
+ * Shortcut for mpd_send_seek_current() and mpd_response_finish().
+ *
+ * @param connection the connection to MPD
+ * @return true on success, false on error
+ *
+ * @since MPD 0.17, libmpdclient 2.15
+ */
 bool
 mpd_run_seek_current(struct mpd_connection *connection,
 		     float t, bool relative);
 
+/**
+ * Sets repeat on/off for the current song.
+ * If mode is true, MPD repeats the song; otherwise, MPD does not repeat the
+ * song.
+ *
+ * @param connection the connection to MPD
+ * @param mode if true: repeat, if false: do not repeat
+ * @return true on success, false on error
+ */
 bool
 mpd_send_repeat(struct mpd_connection *connection, bool mode);
 
+/**
+ * Shortcut for mpd_send_repeat() and mpd_response_finish().
+ *
+ * @param connection the connection to MPD
+ * @param mode if true: pause, if false: resume
+ * @return true on success, false on error
+ */
 bool
 mpd_run_repeat(struct mpd_connection *connection, bool mode);
 
+/**
+ * Sets random mode on/off for the queue.
+ * If mode is true, MPD enables random mode; otherwise, MPD disables random
+ * mode.
+ *
+ * @param connection the connection to MPD
+ * @param mode if true: enable random mode, if false: disable random mode
+ * @return true on success, false on error
+ */
 bool
 mpd_send_random(struct mpd_connection *connection, bool mode);
 
+/**
+ * Shortcut for mpd_send_random() and mpd_response_finish().
+ *
+ * @param connection the connection to MPD
+ * @param mode if true: enable random mode, if false: disable random mode
+ * @return true on success, false on error
+ */
 bool
 mpd_run_random(struct mpd_connection *connection, bool mode);
 
+/**
+ * Sets single mode on/off for the playlist.
+ * If mode is true, MPD enables single mode: playback is stopped after current
+ * song, or song is repeated if the repeat mode is enabled.
+ *
+ * If mode is false, MPD disables single mode: if random mode is enabled, the
+ * playlist order is shuffled after it is played completely.
+ *
+ * @param connection the connection to MPD
+ * @param mode if true: enable single mode, if false: disable single mode
+ * @return true on success, false on error
+ *
+ * @since MPD 0.15
+ */
 bool
 mpd_send_single(struct mpd_connection *connection, bool mode);
 
+/**
+ * Shortcut for mpd_send_single() and mpd_response_finish().
+ *
+ * @param connection the connection to MPD
+ * @param mode if true: enable single mode, if false: disable single mode
+ * @return true on success, false on error
+ *
+ * @since MPD 0.15
+ */
 bool
 mpd_run_single(struct mpd_connection *connection, bool mode);
 
+/**
+ * Sets consume mode on/off for the playlist.
+ * If mode is true, MPD enables consume mode: each song played is removed from
+ * the playlist.
+ *
+ * If mode is false, MPD disables consume mode.
+ *
+ * @param connection the connection to MPD
+ * @param mode if true: enable consume mode, if false: disable consume mode
+ * @return true on success, false on error
+ *
+ * @since MPD 0.15
+ */
 bool
 mpd_send_consume(struct mpd_connection *connection, bool mode);
 
+/**
+ * Shortcut for mpd_send_consume() and mpd_response_finish().
+ *
+ * @param connection the connection to MPD
+ * @param mode if true: enable consume mode, if false: disable consume mode
+ * @return true on success, false on error
+ *
+ * @since MPD 0.15
+ */
 bool
 mpd_run_consume(struct mpd_connection *connection, bool mode);
 
+/**
+ * Sets crossfading of seconds between songs on for the playlist.
+ * Crossfading only happens when the songs audio format are the same.
+ *
+ * @param connection the connection to MPD
+ * @param seconds seconds of crossfading between songs
+ * @return true on success, false on error
+ */
 bool
 mpd_send_crossfade(struct mpd_connection *connection, unsigned seconds);
 
+/**
+ * Shortcut for mpd_send_crossfade() and mpd_response_finish().
+ *
+ * @param connection the connection to MPD
+ * @param seconds seconds of crossfading between songs
+ * @return true on success, false on error
+ */
 bool
 mpd_run_crossfade(struct mpd_connection *connection, unsigned seconds);
 
 /**
+ * Sets the threshold at which songs will be overlapped. Like crossfading but
+ * doesn't fade the track volume, just overlaps.
+ *
+ * The songs need to have MixRamp tags added by an external tool. 0dB is the
+ * normalized maximum volume; so use negative values (I prefer -17dB). In the
+ * absence of MixRamp tags, crossfading will be used.
+ *
+ * @param connection the connection to MPD
+ * @param db decibels of volume for overlapping songs
+ * @return true on success, false on error
+ *
  * @since libmpdclient 2.2
  */
 bool
 mpd_send_mixrampdb(struct mpd_connection *connection, float db);
 
 /**
+ * Shortcut for mpd_send_mixrampdb() and mpd_response_finish().
+ *
+ * @param connection the connection to MPD
+ * @param db decibels of volume for overlapping songs
+ * @return true on success, false on error
+ *
  * @since libmpdclient 2.2
  */
 bool
 mpd_run_mixrampdb(struct mpd_connection *connection, float db);
 
 /**
+ * Sets additional time subtracted from the overlap calculated by mixrampdb.
+ * A value of NaN disables MixRamp overlapping and falls back to crossfading.
+ *
+ * @param connection the connection to MPD
+ * @param seconds seconds subtracted from the overlap calculated by mixrampdb
+ * @return true on success, false on error
+ *
  * @since libmpdclient 2.2
  */
 bool
 mpd_send_mixrampdelay(struct mpd_connection *connection, float seconds);
 
 /**
+ * Shortcut for mpd_send_mixrampdelay() and mpd_response_finish().
+ *
+ * @param connection the connection to MPD
+ * @param seconds seconds subtracted from the overlap calculated by mixrampdb
+ * @return true on success, false on error
+ *
  * @since libmpdclient 2.2
  */
 bool
 mpd_run_mixrampdelay(struct mpd_connection *connection, float seconds);
 
 /**
+ * Clears the current error message in MPD's status (this is also accomplished
+ * by any command that starts playback).
+ *
+ * @param connection the connection to MPD
+ * @return true on success, false on error
+ *
  * @since libmpdclient 2.4
  */
 bool
 mpd_send_clearerror(struct mpd_connection *connection);
 
 /**
+ * Shortcut for mpd_send_clearerror() and mpd_response_finish().
+ *
+ * @param connection the connection to MPD
+ * @return true on success, false on error
+ *
  * @since libmpdclient 2.4
  */
 bool

--- a/include/mpd/player.h
+++ b/include/mpd/player.h
@@ -257,7 +257,8 @@ mpd_run_seek_pos(struct mpd_connection *connection,
  * @return true on success, false on error
  */
 bool
-mpd_send_seek_id(struct mpd_connection *connection, unsigned id, unsigned t);
+mpd_send_seek_id(struct mpd_connection *connection,
+		 unsigned song_id, unsigned t);
 
 /**
  * Shortcut for mpd_send_seek_id() and mpd_response_finish().
@@ -275,13 +276,13 @@ mpd_run_seek_id(struct mpd_connection *connection,
  * Seeks to the position t (in seconds; fractions allowed) of song id song_id.
  *
  * @param connection the connection to MPD
- * @param id the id of the song
+ * @param song_id the id of the song
  * @param t the position within the song, in seconds (fractions allowed)
  * @return true on success, false on error
  */
 bool
 mpd_send_seek_id_float(struct mpd_connection *connection,
-		       unsigned id, float t);
+		       unsigned song_id, float t);
 
 /**
  * Shortcut for mpd_send_seek_id_float() and mpd_response_finish().

--- a/include/mpd/player.h
+++ b/include/mpd/player.h
@@ -133,7 +133,7 @@ mpd_run_play_pos(struct mpd_connection *connection, unsigned song_pos);
  * @return true on success, false on error
  */
 bool
-mpd_send_play_id(struct mpd_connection *connection, unsigned id);
+mpd_send_play_id(struct mpd_connection *connection, unsigned song_id);
 
 /**
  * Shortcut for mpd_send_play_id() and mpd_response_finish().

--- a/include/mpd/player.h
+++ b/include/mpd/player.h
@@ -49,6 +49,23 @@ extern "C" {
 #endif
 
 /**
+ * There are two ways to address songs within the queue: by their position and
+ * by their id.
+ * The position is a 0-based index. It is unstable by design: if you move,
+ * delete or insert songs, all following indices will change, and a client can
+ * never be sure what song is behind a given index/position.
+ *
+ * Song ids on the other hand are stable: an id is assigned to a song when it
+ * is added, and will stay the same, no matter how much it is moved around.
+ * Adding the same song twice will assign different ids to them, and a
+ * deleted-and-readded song will have a new id. This way, a client can always
+ * be sure the correct song is being used.
+ *
+ * Many commands come in two flavors, one for each address type. Whenever
+ * possible, ids should be used.
+ */
+
+/**
  * Fetches the currently selected song (the song referenced by
  * mpd_status_get_song_id()).
  * Call mpd_recv_song() to receive the response.

--- a/src/list.c
+++ b/src/list.c
@@ -82,6 +82,8 @@ mpd_command_list_end(struct mpd_connection *connection)
 
 	connection->sending_command_list = false;
 	success = mpd_send_command(connection, "command_list_end", NULL);
+	/* sending_command_list will be cleared when the user requests the
+	   command list response (a function that calls mpd_recv_pair()) */
 	connection->sending_command_list = true;
 	if (!success)
 		return false;

--- a/src/player.c
+++ b/src/player.c
@@ -90,9 +90,9 @@ mpd_run_play_pos(struct mpd_connection *connection, unsigned song_pos)
 }
 
 bool
-mpd_send_play_id(struct mpd_connection *connection, unsigned id)
+mpd_send_play_id(struct mpd_connection *connection, unsigned song_id)
 {
-	return mpd_send_int_command(connection, "playid", id);
+	return mpd_send_int_command(connection, "playid", song_id);
 }
 
 bool
@@ -186,9 +186,10 @@ mpd_run_seek_pos(struct mpd_connection *connection,
 }
 
 bool
-mpd_send_seek_id(struct mpd_connection *connection, unsigned id, unsigned t)
+mpd_send_seek_id(struct mpd_connection *connection,
+		 unsigned song_id, unsigned t)
 {
-	return mpd_send_int2_command(connection, "seekid", id, t);
+	return mpd_send_int2_command(connection, "seekid", song_id, t);
 }
 
 bool
@@ -202,9 +203,9 @@ mpd_run_seek_id(struct mpd_connection *connection,
 
 bool
 mpd_send_seek_id_float(struct mpd_connection *connection,
-		       unsigned id, float t)
+		       unsigned song_id, float t)
 {
-	return mpd_send_u_f_command(connection, "seekid", id, t);
+	return mpd_send_u_f_command(connection, "seekid", song_id, t);
 }
 
 bool


### PR DESCRIPTION
Hello,
this is a multi-commit series for improving the documentation of multiple "subsystems" of libmpdclient
most of the fixes are minor, except for the player subsystem.
here's a summary:
idle subsystem:
https://github.com/MusicPlayerDaemon/libmpdclient/commit/fe7fe6077675a4f7e980f3a911e66eebbc24ad3a: minor update adding missing parameters/return types for idle
https://github.com/MusicPlayerDaemon/libmpdclient/commit/8cc2ee8ed434cf5cb594fef6582234889eb09dc2: minor typo in `mpd_recv_idle()` for idle subsystem

list subsystem:
https://github.com/MusicPlayerDaemon/libmpdclient/commit/df4b815f74e68160fdc3ecb6b0a2275787866e42: clarify why `mpd_command_list_end()` sets `sending_command_list` to `true`

mount subsystem:
https://github.com/MusicPlayerDaemon/libmpdclient/commit/34d8b547c69f7078867578a3d07731efa7285228: clarify that `mpd_mount_free()` can also be used with `mpd_mount_begin()`

output subsystem:
https://github.com/MusicPlayerDaemon/libmpdclient/commit/5c49e0f8fadf361cbb57875347754ed41d8422c2: clarify mpd commands ("output", "outputset") which may not be obvious; additionally, identify another use-case for `mpd_output_free()` (similar to  commit 34d8b547c69f7078867578a3d07731efa7285228)

async subsystem:
https://github.com/MusicPlayerDaemon/libmpdclient/commit/38f19df2901fb6731ddc2e1e064c2b73c44e8686: link documentation of `mpd_async_recv_line()` with `mpd_parser_new()/``mpd_parser_feed()`

player subsystem:
https://github.com/MusicPlayerDaemon/libmpdclient/commit/9bd8a6bf1917426148d00403d69cc4fbb66e0268: document all missing functions
https://github.com/MusicPlayerDaemon/libmpdclient/commit/78caf4b5e82bb8e25a807ccbb02b792b78bc357d: ensure that all references to song_id use the parameter name `song_id`
https://github.com/MusicPlayerDaemon/libmpdclient/commit/4bc7a527dbdf4edbaa29fc1eeb3f84f0b16f60e3: missed a spot (`mpd_send_play_id()`) and the update to player.c file (id => song_id)
https://github.com/MusicPlayerDaemon/libmpdclient/pull/40/commits/c80beffe7d73af1efb024064bfe8307f46c82334: provide rationale to use song ids in place of song positions
