### PR TITLE
improve documentation of multiple libmpdclient functions

### DIFF
--- a/include/mpd/async.h
+++ b/include/mpd/async.h
@@ -224,6 +224,8 @@ mpd_async_recv_line(struct mpd_async *async);
  * @param length of bytes to consume
  * @return the number of bytes copied to the destination buffer (may
  * be 0 if the input buffer was empty)
+ *
+ * @since libmpdclient 2.17
  */
 size_t
 mpd_async_recv_raw(struct mpd_async *async, void *dest, size_t length);

--- a/include/mpd/queue.h
+++ b/include/mpd/queue.h
@@ -51,12 +51,17 @@ extern "C" {
 /**
  * Sends the "playlistinfo" command: list all songs in the queue
  * including meta information.
+ * Use mpd_recv_entity() to receive the songs (#MPD_ENTITY_TYPE_SONG).
+ *
+ * @param connection the connection to MPD
+ * @return true on success, false on error
  */
 bool
 mpd_send_list_queue_meta(struct mpd_connection *connection);
 
 /**
  * Like mpd_send_list_queue_meta(), but specifies a (position) range.
+ * Use mpd_recv_entity() to receive the songs (#MPD_ENTITY_TYPE_SONG).
  *
  * @param connection the connection to MPD
  * @param start the start position of the range (including)
@@ -73,6 +78,7 @@ mpd_send_list_queue_range_meta(struct mpd_connection *connection,
 /**
  * Requests information (including tags) about one song in the
  * playlist (command "playlistid").
+ * Use mpd_recv_song() to obtain the song information.
  *
  * @param connection the connection to MPD
  * @param pos the position of the requested song
@@ -94,6 +100,7 @@ mpd_run_get_queue_song_pos(struct mpd_connection *connection, unsigned pos);
 /**
  * Requests information (including tags) about one song in the
  * playlist (command "playlistid").
+ * Use mpd_recv_song() to obtain the song information.
  *
  * @param connection the connection to MPD
  * @param id the id of the requested song
@@ -116,6 +123,9 @@ mpd_run_get_queue_song_id(struct mpd_connection *connection, unsigned id);
  * Request the queue changes from MPD since the specified version,
  * including tags.  The MPD command is called "plchanges".
  *
+ * The current version can be fetched with mpd_status_get_queue_version().
+ * Use mpd_recv_song() to receive the songs of the new version.
+ *
  * @param connection the connection to MPD
  * @param version The playlist version you want the diff with.
  * @return true on success, false on error
@@ -128,7 +138,11 @@ mpd_send_queue_changes_meta(struct mpd_connection *connection,
  * Same as mpd_send_queue_changes_meta(), but limit the result to a
  * range.
  *
+ * The current version can be fetched with mpd_status_get_queue_version().
+ * Use mpd_recv_song() to receive the songs of the new queue.
+ *
  * @param connection the connection to MPD
+ * @param version The playlist version you want the diff with.
  * @param start the start position of the range (including)
  * @param end the end position of the range (excluding); the special
  * value "UINT_MAX" makes the end of the range open
@@ -146,6 +160,8 @@ mpd_send_queue_changes_meta_range(struct mpd_connection *connection,
  * mpd_send_queue_changes_meta().  It only returns the position and id
  * of changed songs.  The MPD command is called "plchangesposid".
  *
+ * Use mpd_recv_queue_change_brief() for the response.
+ *
  * @param connection A valid and connected mpd_connection.
  * @param version The playlist version you want the diff with.
  * @return true on success, false on error
@@ -157,6 +173,8 @@ mpd_send_queue_changes_brief(struct mpd_connection *connection,
 /**
  * Same as mpd_send_queue_changes_brief(), but limit the result to a
  * range.
+ *
+ * Use mpd_recv_queue_change_brief() for the response.
  *
  * @param connection the connection to MPD
  * @param start the start position of the range (including)
@@ -172,7 +190,8 @@ mpd_send_queue_changes_brief_range(struct mpd_connection *connection,
 				   unsigned start, unsigned end);
 
 /**
- * Receives a response element of mpd_send_queue_changes_brief().
+ * Receives a response element of mpd_send_queue_changes_brief() or
+ * mpd_send_queue_changes_brief_range().
  *
  * @param connection A valid and connected mpd_connection.
  * @param position_r reference to the position of the changed song
@@ -185,7 +204,11 @@ mpd_recv_queue_change_brief(struct mpd_connection *connection,
 			    unsigned *position_r, unsigned *id_r);
 
 /**
- * Appends a song to the playlist.
+ * Appends a song to the playlist: either a single file or a directory.
+ *
+ * @param connection A valid and connected mpd_connection.
+ * @param file URI of a song or directory (added recursively)
+ * @return true on success, false on error
  */
 bool
 mpd_send_add(struct mpd_connection *connection, const char *file);
@@ -194,20 +217,26 @@ mpd_send_add(struct mpd_connection *connection, const char *file);
  * Shortcut for mpd_send_add() and mpd_response_finish().
  *
  * @param connection the connection to MPD
- * @param uri the URI of the song to be added
+ * @param file URI of a song or directory (added recursively)
  * @return true on success, false on error
  */
 bool
 mpd_run_add(struct mpd_connection *connection, const char *uri);
 
 /**
- * Appends a song to the playlist, and returns its id.
+ * Appends a song to the playlist. Call mpd_recv_song_id() for its id.
+ * file is always a single file or URL.
+ *
+ * @param connection the connection to MPD
+ * @param file URI of the song to be added
+ * @return true on success, false on error
  */
 bool
 mpd_send_add_id(struct mpd_connection *connection, const char *file);
 
 /**
- * Inserts a song into the playlist, and returns its id.
+ * Inserts a song into the playlist for a given position, and returns its id.
+ * file is always a single file or URL.
  *
  * @param connection the connection to MPD
  * @param uri the URI of the song to be added
@@ -220,8 +249,9 @@ mpd_send_add_id_to(struct mpd_connection *connection, const char *uri,
 
 /**
  * Returns the id of the new song in the playlist.  To be called after
- * mpd_send_add_id().
+ * mpd_send_add_id() or mpd_send_add_id_to().
  *
+ * @param connection the connection to MPD
  * @return the new song id, -1 on error or if MPD did not send an id
  */
 int
@@ -229,7 +259,10 @@ mpd_recv_song_id(struct mpd_connection *connection);
 
 /**
  * Executes the "addid" command and reads the response.
+ * file is always a single file or URL.
  *
+ * @param connection the connection to MPD
+ * @param file URI of a song to be added
  * @return the new song id, -1 on error or if MPD did not send an id
  */
 int
@@ -237,6 +270,7 @@ mpd_run_add_id(struct mpd_connection *connection, const char *file);
 
 /**
  * Executes the "addid" command and reads the response.
+ * file is always a single file or URL.
  *
  * @param connection the connection to MPD
  * @param uri the URI of the song to be added
@@ -252,6 +286,7 @@ mpd_run_add_id_to(struct mpd_connection *connection, const char *uri,
  *
  * @param connection the connection to MPD
  * @param pos the position of the song to be deleted
+ * @return true on success, false on error
  */
 bool
 mpd_send_delete(struct mpd_connection *connection, unsigned pos);
@@ -301,6 +336,7 @@ mpd_run_delete_range(struct mpd_connection *connection,
  *
  * @param connection the connection to MPD
  * @param id the id of the song to be deleted
+ * @return true on success, false on error
  */
 bool
 mpd_send_delete_id(struct mpd_connection *connection, unsigned id);
@@ -319,6 +355,7 @@ mpd_run_delete_id(struct mpd_connection *connection, unsigned id);
  * Shuffles the queue.
  *
  * @param connection the connection to MPD
+ * @return true on success, false on error
  */
 bool
 mpd_send_shuffle(struct mpd_connection *connection);
@@ -327,6 +364,7 @@ mpd_send_shuffle(struct mpd_connection *connection);
  * Shortcut for mpd_send_shuffle() and mpd_response_finish().
  *
  * @param connection the connection to MPD
+ * @return true on success, false on error
  */
 bool
 mpd_run_shuffle(struct mpd_connection *connection);
@@ -338,11 +376,13 @@ mpd_run_shuffle(struct mpd_connection *connection);
  * @param start the start position of the range (including)
  * @param end the end position of the range (excluding); the special
  * value "UINT_MAX" makes the end of the range open
+ * @return true on success, false on error
  *
  * @since libmpdclient 2.8 added support for "UINT_MAX"
  */
 bool
-mpd_send_shuffle_range(struct mpd_connection *connection, unsigned start, unsigned end);
+mpd_send_shuffle_range(struct mpd_connection *connection,
+		       unsigned start, unsigned end);
 
 /**
  * Shortcut for mpd_send_shuffle_range() and mpd_response_finish().
@@ -351,6 +391,7 @@ mpd_send_shuffle_range(struct mpd_connection *connection, unsigned start, unsign
  * @param start the start position of the range (including)
  * @param end the end position of the range (excluding); the special
  * value "UINT_MAX" makes the end of the range open
+ * @return true on success, false on error
  *
  * @since libmpdclient 2.8 added support for "UINT_MAX"
  */
@@ -362,6 +403,7 @@ mpd_run_shuffle_range(struct mpd_connection *connection,
  * Clear the queue.
  *
  * @param connection the connection to MPD
+ * @return true on success, false on error
  */
 bool
 mpd_send_clear(struct mpd_connection *connection);
@@ -370,6 +412,7 @@ mpd_send_clear(struct mpd_connection *connection);
  * Shortcut for mpd_send_clear() and mpd_response_finish().
  *
  * @param connection the connection to MPD
+ * @return true on success, false on error
  */
 bool
 mpd_run_clear(struct mpd_connection *connection);
@@ -380,6 +423,7 @@ mpd_run_clear(struct mpd_connection *connection);
  * @param connection the connection to MPD
  * @param from the source song position
  * @param to the new position of the song
+ * @return true on success, false on error
  */
 bool
 mpd_send_move(struct mpd_connection *connection, unsigned from, unsigned to);
@@ -390,6 +434,7 @@ mpd_send_move(struct mpd_connection *connection, unsigned from, unsigned to);
  * @param connection the connection to MPD
  * @param from the source song position
  * @param to the new position of the song
+ * @return true on success, false on error
  */
 bool
 mpd_run_move(struct mpd_connection *connection, unsigned from, unsigned to);
@@ -400,6 +445,7 @@ mpd_run_move(struct mpd_connection *connection, unsigned from, unsigned to);
  * @param connection the connection to MPD
  * @param from the source song id
  * @param to the new position of the song (not an id!)
+ * @return true on success, false on error
  */
 bool
 mpd_send_move_id(struct mpd_connection *connection, unsigned from, unsigned to);
@@ -410,6 +456,7 @@ mpd_send_move_id(struct mpd_connection *connection, unsigned from, unsigned to);
  * @param connection the connection to MPD
  * @param from the source song id
  * @param to the new position of the song (not an id!)
+ * @return true on success, false on error
  */
 bool
 mpd_run_move_id(struct mpd_connection *connection, unsigned from, unsigned to);
@@ -431,7 +478,7 @@ mpd_send_move_range(struct mpd_connection *connection,
 		    unsigned start, unsigned end, unsigned to);
 
 /**
- * Shortcut for mpd_send_move_id() and mpd_response_finish().
+ * Shortcut for mpd_send_move_range() and mpd_response_finish().
  *
  * @param connection the connection to MPD
  * @param start the start position of the range (including)
@@ -452,6 +499,7 @@ mpd_run_move_range(struct mpd_connection *connection,
  * @param connection the connection to MPD
  * @param pos1 the position of one song
  * @param pos2 the position of the other song
+ * @return true on success, false on error
  */
 bool
 mpd_send_swap(struct mpd_connection *connection, unsigned pos1, unsigned pos2);
@@ -462,6 +510,7 @@ mpd_send_swap(struct mpd_connection *connection, unsigned pos1, unsigned pos2);
  * @param connection the connection to MPD
  * @param pos1 the position of one song
  * @param pos2 the position of the other song
+ * @return true on success, false on error
  */
 bool
 mpd_run_swap(struct mpd_connection *connection, unsigned pos1, unsigned pos2);
@@ -472,6 +521,7 @@ mpd_run_swap(struct mpd_connection *connection, unsigned pos1, unsigned pos2);
  * @param connection the connection to MPD
  * @param id1 the id of one song
  * @param id2 the id of the other song
+ * @return true on success, false on error
  */
 bool
 mpd_send_swap_id(struct mpd_connection *connection, unsigned id1, unsigned id2);
@@ -482,6 +532,7 @@ mpd_send_swap_id(struct mpd_connection *connection, unsigned id1, unsigned id2);
  * @param connection the connection to MPD
  * @param id1 the id of one song
  * @param id2 the id of the other song
+ * @return true on success, false on error
  */
 bool
 mpd_run_swap_id(struct mpd_connection *connection, unsigned id1, unsigned id2);
@@ -493,6 +544,7 @@ mpd_run_swap_id(struct mpd_connection *connection, unsigned id1, unsigned id2);
  * @param id the id of the song
  * @param tag the tag to be added
  * @param value the tag value
+ * @return true on success, false on error
  *
  * @since libmpdclient 2.12, MPD 0.19
  */
@@ -507,6 +559,7 @@ mpd_send_add_tag_id(struct mpd_connection *connection, unsigned id,
  * @param id the id of the song
  * @param tag the tag to be added
  * @param value the tag value
+ * @return true on success, false on error
  *
  * @since libmpdclient 2.12, MPD 0.19
  */
@@ -520,6 +573,7 @@ mpd_run_add_tag_id(struct mpd_connection *connection, unsigned id,
  * @param connection the connection to MPD
  * @param id the id of the song
  * @param tag the tag to be cleared
+ * @return true on success, false on error
  *
  * @since libmpdclient 2.12, MPD 0.19
  */
@@ -533,6 +587,7 @@ mpd_send_clear_tag_id(struct mpd_connection *connection, unsigned id,
  * @param connection the connection to MPD
  * @param id the id of the song
  * @param tag the tag to be cleared
+ * @return true on success, false on error
  *
  * @since libmpdclient 2.12, MPD 0.19
  */
@@ -545,6 +600,7 @@ mpd_run_clear_tag_id(struct mpd_connection *connection, unsigned id,
  *
  * @param connection the connection to MPD
  * @param id the id of the song
+ * @return true on success, false on error
  *
  * @since libmpdclient 2.12, MPD 0.19
  */
@@ -556,6 +612,7 @@ mpd_send_clear_all_tags_id(struct mpd_connection *connection, unsigned id);
  *
  * @param connection the connection to MPD
  * @param id the id of the song
+ * @return true on success, false on error
  *
  * @since libmpdclient 2.12, MPD 0.19
  */
@@ -568,6 +625,7 @@ mpd_run_clear_all_tags_id(struct mpd_connection *connection, unsigned id);
  * @param connection the connection to MPD
  * @param priority a number between 0 and 255
  * @param position the position of the song
+ * @return true on success, false on error
  *
  * @since libmpdclient 2.6
  */
@@ -581,6 +639,7 @@ mpd_send_prio(struct mpd_connection *connection, int priority,
  * @param connection the connection to MPD
  * @param priority a number between 0 and 255
  * @param position the position of the song
+ * @return true on success, false on error
  *
  * @since libmpdclient 2.6
  */
@@ -596,6 +655,7 @@ mpd_run_prio(struct mpd_connection *connection, int priority,
  * @param start the start position of the range (including)
  * @param end the end position of the range (excluding); the special
  * value "UINT_MAX" makes the end of the range open
+ * @return true on success, false on error
  *
  * @since libmpdclient 2.6
  * @since libmpdclient 2.8 added support for "UINT_MAX"
@@ -612,6 +672,7 @@ mpd_send_prio_range(struct mpd_connection *connection, int priority,
  * @param start the start position of the range (including)
  * @param end the end position of the range (excluding); the special
  * value "UINT_MAX" makes the end of the range open
+ * @return true on success, false on error
  *
  * @since libmpdclient 2.6
  * @since libmpdclient 2.8 added support for "UINT_MAX"
@@ -626,6 +687,7 @@ mpd_run_prio_range(struct mpd_connection *connection, int priority,
  * @param connection the connection to MPD
  * @param priority a number between 0 and 255
  * @param id the id of the song
+ * @return true on success, false on error
  *
  * @since libmpdclient 2.6
  */
@@ -639,6 +701,7 @@ mpd_send_prio_id(struct mpd_connection *connection, int priority,
  * @param connection the connection to MPD
  * @param priority a number between 0 and 255
  * @param id the id of the song
+ * @return true on success, false on error
  *
  * @since libmpdclient 2.6
  */

--- a/include/mpd/queue.h
+++ b/include/mpd/queue.h
@@ -49,6 +49,11 @@ extern "C" {
 #endif
 
 /**
+ * Consult mpd/playlist.h for the rationale on the preference of manipulating
+ * song ids over positions in the queue.
+ */
+
+/**
  * Sends the "playlistinfo" command: list all songs in the queue
  * including meta information.
  * Use mpd_recv_entity() to receive the songs (#MPD_ENTITY_TYPE_SONG).

--- a/include/mpd/recv.h
+++ b/include/mpd/recv.h
@@ -56,6 +56,8 @@ extern "C" {
  * The caller must allocate length bytes of memory for data.
  *
  * @return true on success
+ *
+ * @since libmpdclient 2.17
  */
 bool
 mpd_recv_binary(struct mpd_connection *connection, void *data, size_t length);

--- a/include/mpd/search.h
+++ b/include/mpd/search.h
@@ -98,6 +98,8 @@ mpd_search_add_db_songs(struct mpd_connection *connection, bool exact);
  *
  * @param connection the connection to MPD
  * @return true on success, false on error
+ *
+ * @since libmpdclient 2.17.
  */
 bool
 mpd_search_add_db_songs_to_playlist(struct mpd_connection *connection,
@@ -216,7 +218,7 @@ mpd_search_add_modified_since_constraint(struct mpd_connection *connection,
  *
  * @param connection a #mpd_connection
  * @param expression the expression string; must be enclosed in
- * parantheses
+ * parentheses
  * @return true on success, false on error
  *
  * @since libmpdclient 2.15, MPD 0.21

--- a/include/mpd/song.h
+++ b/include/mpd/song.h
@@ -130,8 +130,7 @@ mpd_song_get_start(const struct mpd_song *song);
 
 /**
  * Returns the end of the virtual song within the physical file in
- * seconds.  Zero means that the physical song file is played to the
- * end.
+ * seconds. 0 means that the physical song file is played to the end.
  *
  * @since libmpdclient 2.3
  */

--- a/include/mpd/stats.h
+++ b/include/mpd/stats.h
@@ -59,7 +59,7 @@ extern "C" {
 #endif
 
 /**
- * Send the "stats" command to MPD.
+ * Send the "stats" command to MPD. Call mpd_recv_stats() to read the response.
  *
  * @return true on success
  */
@@ -103,7 +103,7 @@ mpd_run_stats(struct mpd_connection *connection);
 /**
  * Frees a #mpd_stats object.
  */
-void mpd_stats_free(struct mpd_stats * stats);
+void mpd_stats_free(struct mpd_stats *stats);
 
 /**
  * @return the number of distinct artists in MPD's database, or 0 if
@@ -111,7 +111,7 @@ void mpd_stats_free(struct mpd_stats * stats);
  */
 mpd_pure
 unsigned
-mpd_stats_get_number_of_artists(const struct mpd_stats * stats);
+mpd_stats_get_number_of_artists(const struct mpd_stats *stats);
 
 /**
  * @return the number of distinct album names in MPD's database, or 0
@@ -119,7 +119,7 @@ mpd_stats_get_number_of_artists(const struct mpd_stats * stats);
  */
 mpd_pure
 unsigned
-mpd_stats_get_number_of_albums(const struct mpd_stats * stats);
+mpd_stats_get_number_of_albums(const struct mpd_stats *stats);
 
 /**
  * @return the total number of song files in MPD's database, or 0 if
@@ -127,34 +127,34 @@ mpd_stats_get_number_of_albums(const struct mpd_stats * stats);
  */
 mpd_pure
 unsigned
-mpd_stats_get_number_of_songs(const struct mpd_stats * stats);
+mpd_stats_get_number_of_songs(const struct mpd_stats *stats);
 
 /**
  * @return the uptime of MPD in seconds, or 0 if unknown
  */
 mpd_pure
-unsigned long mpd_stats_get_uptime(const struct mpd_stats * stats);
+unsigned long mpd_stats_get_uptime(const struct mpd_stats *stats);
 
 /**
  * @return the UNIX time stamp of the last database update, or 0 if
  * unknown
  */
 mpd_pure
-unsigned long mpd_stats_get_db_update_time(const struct mpd_stats * stats);
+unsigned long mpd_stats_get_db_update_time(const struct mpd_stats *stats);
 
 /**
  * @return the accumulated time MPD was playing music since the
  * process was started, or 0 if unknown
  */
 mpd_pure
-unsigned long mpd_stats_get_play_time(const struct mpd_stats * stats);
+unsigned long mpd_stats_get_play_time(const struct mpd_stats *stats);
 
 /**
  * @return the accumulated duration of all songs in the database, or 0
  * if unknown
  */
 mpd_pure
-unsigned long mpd_stats_get_db_play_time(const struct mpd_stats * stats);
+unsigned long mpd_stats_get_db_play_time(const struct mpd_stats *stats);
 
 #ifdef __cplusplus
 }

--- a/include/mpd/status.h
+++ b/include/mpd/status.h
@@ -193,7 +193,7 @@ unsigned
 mpd_status_get_crossfade(const struct mpd_status *status);
 
 /**
- * Returns mixrampdb setting in db.
+ * Returns mixrampdb setting in db. 0 means mixrampdb is disabled.
  *
  * @since libmpdclient 2.2
  */
@@ -202,7 +202,7 @@ float
 mpd_status_get_mixrampdb(const struct mpd_status *status);
 
 /**
- * Returns mixrampdelay setting in seconds.  Negative means mixramp is
+ * Returns mixrampdelay setting in seconds.  Negative means mixrampdelay is
  * disabled.
  *
  * @since libmpdclient 2.2
@@ -214,7 +214,8 @@ mpd_status_get_mixrampdelay(const struct mpd_status *status);
 /**
  * Returns the position of the currently playing song in the queue
  * (beginning with 0) if a song is currently selected (always the case when
- * state is PLAY or PAUSE).  If there is no current song, -1 is returned.
+ * state is MPD_STATE_PLAY or MPD_STATE_PAUSE).  If there is no current song,
+ * -1 is returned.
  */
 mpd_pure
 int
@@ -229,7 +230,7 @@ int
 mpd_status_get_song_id(const struct mpd_status *status);
 
 /**
- * The same as mpd_status_get_next_song_pos, but for the next song to be
+ * The same as mpd_status_get_song_pos(), but for the next song to be
  * played.
  *
  * @since libmpdclient 2.7
@@ -253,7 +254,8 @@ mpd_status_get_next_song_id(const struct mpd_status *status);
  * mpd_status_get_elapsed_ms() instead.
  *
  * Returns time in seconds that have elapsed in the currently playing/paused
- * song
+ * song.
+ *
  */
 mpd_pure
 unsigned

--- a/include/mpd/status.h
+++ b/include/mpd/status.h
@@ -249,6 +249,9 @@ int
 mpd_status_get_next_song_id(const struct mpd_status *status);
 
 /**
+ * This function uses a deprecated feature of MPD, call
+ * mpd_status_get_elapsed_ms() instead.
+ *
  * Returns time in seconds that have elapsed in the currently playing/paused
  * song
  */

--- a/include/mpd/sticker.h
+++ b/include/mpd/sticker.h
@@ -49,6 +49,24 @@ extern "C" {
 #endif
 
 /**
+ * Stickers are pieces of information attached to existing MPD objects (e.g.
+ * song files, directories, albums; but currently, they are only implemented
+ * for song). Clients can create arbitrary name/value pairs. MPD itself does
+ * not assume any special meaning in them.
+ *
+ * The goal is to allow clients to share additional (possibly dynamic)
+ * information about songs, which is neither stored on the client (not
+ * available to other clients), nor stored in the song files (MPD has no write
+ * access).
+ *
+ * Client developers should create a standard for common sticker names, to
+ * ensure interoperability.
+ *
+ * Objects which may have stickers are addressed by their object type ("song"
+ * for song objects) and their URI (the path within the database for songs).
+ */
+
+/**
  * Adds or replaces a sticker value.
  *
  * @param connection the connection to MPD
@@ -141,7 +159,8 @@ mpd_send_sticker_list(struct mpd_connection *connection, const char *type,
 		      const char *uri);
 
 /**
- * Searches for stickers with the specified name.
+ * Searches for stickers with the specified name. Call mpd_recv_sticker() to
+ * receive each response item.
  *
  * @param connection the connection to MPD
  * @param type the object type, e.g. "song"

--- a/include/mpd/tag.h
+++ b/include/mpd/tag.h
@@ -36,7 +36,11 @@
 /**
  * @since libmpdclient 2.10 added support for #MPD_TAG_MUSICBRAINZ_RELEASETRACKID.
  * @since libmpdclient 2.11 added support for #MPD_TAG_ARTIST_SORT and #MPD_TAG_ALBUM_ARTIST_SORT
- * @since libmpdclient 2.17 added support for #MPD_TAG_LABEL and #MPD_TAG_MUSICBRAINZ_WORKID.
+ * @since libmpdclient 2.17 added support for #MPD_TAG_LABEL,
+ *                                            #MPD_TAG_MUSICBRAINZ_WORKID,
+ *                                            #MPD_TAG_GROUPING,
+ *                                            #MPD_TAG_WORK,
+ *                                            #MPD_TAG_CONDUCTOR.
  */
 enum mpd_tag_type
 {


### PR DESCRIPTION
Hello, this is a multi-commit series to improve the documentation of multiple 
libmpdclient APIs; the subsystems are: async, playlist, queue, recv, search, 
song, stats, status, tag, and sticker.

32f5550c267aaa9834e3d96e553c4c2a813541e9, 05e60dcc56189ad47d52f5e01546275447b3a1c0, 3bb8b43d344bb5ab2ba42f9a333054af18604286: identify functions/tags that require libmpdclient 2.17

16821a2ac86699e6e516c4831ed95fd1db9fdc25: identifies another function added to libmpdclient 2.17

d945a8b3ec2be80911712a8c293ab410770ad12e: completes the API documentation for the playlist API

d945a8b3ec2be80911712a8c293ab410770ad12e: completes the API documentation for the queue API

28a918c36ee79af56a383433990de3b1cf8531da: link the queue API to the explanation on `mpd/playlist.h` for the preference of manipulation songs ids over positions in the queue (thus avoiding have the same text twice)

db44d1b7daa7e9e44348d66c2e311b3e894468e6: minor fix for consistency in the song API

860a566cf3a7b910895b20389d6e5da5e3717546: makes it explicit how to fetch the response for `mpd_send_stats()` + minor fixes for consistencies

f8b0ac4095594098eaf570bb9fa0cabd242b420f: mark `mpd_status_get_elapsed_time()` as deprecated because it uses a deprecated feature of MPD

72491bc854a19f7c45815ac73c01562b30fdeddd: fixes for the status API

917407aff76c40bab56fa8abfd6c2ba1ed3296e5: Give an explanation on the use of stickers. Otherwise, I believe it is difficult to understand it with just the sticker API.

----------------------------------------------------------
This should be the last series of commits on documentation.
