### PR TITLE
Patches for out of memory events

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -142,6 +142,11 @@ mpd_connection_new(const char *host, unsigned port, unsigned timeout_ms)
 			mpd_settings_free(settings);
 			settings = mpd_settings_new(DEFAULT_HOST, DEFAULT_PORT,
 						    timeout_ms, NULL, NULL);
+			if (settings == NULL) {
+				mpd_error_code(&connection->error,
+					       MPD_ERROR_OOM);
+				return connection;
+			}
 			connection->settings = settings;
 
 			mpd_error_clear(&connection->error);

--- a/src/song.c
+++ b/src/song.c
@@ -235,6 +235,8 @@ mpd_song_dup(const struct mpd_song *song)
 const char *
 mpd_song_get_uri(const struct mpd_song *song)
 {
+	assert(song != NULL);
+
 	return song->uri;
 }
 
@@ -338,6 +340,8 @@ mpd_song_set_duration(struct mpd_song *song, unsigned duration)
 unsigned
 mpd_song_get_duration(const struct mpd_song *song)
 {
+	assert(song != NULL);
+
 	return song->duration > 0
 		? song->duration
 		: (song->duration_ms + 500u) / 1000u;
@@ -352,6 +356,8 @@ mpd_song_set_duration_ms(struct mpd_song *song, unsigned duration_ms)
 unsigned
 mpd_song_get_duration_ms(const struct mpd_song *song)
 {
+	assert(song != NULL);
+
 	return song->duration_ms > 0
 		? song->duration_ms
 		: (song->duration * 1000u);
@@ -360,12 +366,16 @@ mpd_song_get_duration_ms(const struct mpd_song *song)
 unsigned
 mpd_song_get_start(const struct mpd_song *song)
 {
+	assert(song != NULL);
+
 	return song->start;
 }
 
 unsigned
 mpd_song_get_end(const struct mpd_song *song)
 {
+	assert(song != NULL);
+
 	return song->end;
 }
 
@@ -378,18 +388,24 @@ mpd_song_set_last_modified(struct mpd_song *song, time_t mtime)
 time_t
 mpd_song_get_last_modified(const struct mpd_song *song)
 {
+	assert(song != NULL);
+
 	return song->last_modified;
 }
 
 void
 mpd_song_set_pos(struct mpd_song *song, unsigned pos)
 {
+	assert(song != NULL);
+
 	song->pos = pos;
 }
 
 unsigned
 mpd_song_get_pos(const struct mpd_song *song)
 {
+	assert(song != NULL);
+
 	return song->pos;
 }
 
@@ -402,6 +418,8 @@ mpd_song_set_id(struct mpd_song *song, unsigned id)
 unsigned
 mpd_song_get_id(const struct mpd_song *song)
 {
+	assert(song != NULL);
+
 	return song->id;
 }
 
@@ -414,12 +432,16 @@ mpd_song_set_prio(struct mpd_song *song, unsigned prio)
 unsigned
 mpd_song_get_prio(const struct mpd_song *song)
 {
+	assert(song != NULL);
+
 	return song->prio;
 }
 
 const struct mpd_audio_format *
 mpd_song_get_audio_format(const struct mpd_song *song)
 {
+	assert(song != NULL);
+
 	return !mpd_audio_format_is_empty(&song->audio_format)
 		? &song->audio_format
 		: NULL;

--- a/src/status.c
+++ b/src/status.c
@@ -35,6 +35,7 @@
 #include <mpd/audio_format.h>
 #include "iaf.h"
 
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -196,6 +197,9 @@ parse_mpd_state(const char *p)
 void
 mpd_status_feed(struct mpd_status *status, const struct mpd_pair *pair)
 {
+	assert(status != NULL);
+	assert(pair != NULL);
+
 	if (strcmp(pair->name, "volume") == 0)
 		status->volume = atoi(pair->value);
 	else if (strcmp(pair->name, "repeat") == 0)
@@ -255,91 +259,122 @@ mpd_status_feed(struct mpd_status *status, const struct mpd_pair *pair)
 		mpd_parse_audio_format(&status->audio_format, pair->value);
 }
 
-void mpd_status_free(struct mpd_status * status) {
+void mpd_status_free(struct mpd_status * status)
+{
+	assert(status != NULL);
+
 	free(status->error);
 	free(status);
 }
 
 int mpd_status_get_volume(const struct mpd_status *status)
 {
+	assert(status != NULL);
+
 	return status->volume;
 }
 
 bool
 mpd_status_get_repeat(const struct mpd_status *status)
 {
+	assert(status != NULL);
+
 	return status->repeat;
 }
 
 bool
 mpd_status_get_random(const struct mpd_status *status)
 {
+	assert(status != NULL);
+
 	return status->random;
 }
 
 bool
 mpd_status_get_single(const struct mpd_status *status)
 {
+	assert(status != NULL);
+
 	return status->single;
 }
 
 bool
 mpd_status_get_consume(const struct mpd_status *status)
 {
+	assert(status != NULL);
+
 	return status->consume;
 }
 
 unsigned
 mpd_status_get_queue_length(const struct mpd_status *status)
 {
+	assert(status != NULL);
+
 	return status->queue_length;
 }
 
 unsigned
 mpd_status_get_queue_version(const struct mpd_status *status)
 {
+	assert(status != NULL);
+
 	return status->queue_version;
 }
 
 enum mpd_state
 mpd_status_get_state(const struct mpd_status *status)
 {
+	assert(status != NULL);
+
 	return status->state;
 }
 
 unsigned
 mpd_status_get_crossfade(const struct mpd_status *status)
 {
+	assert(status != NULL);
+
 	return status->crossfade;
 }
 
 float
 mpd_status_get_mixrampdb(const struct mpd_status *status)
 {
+	assert(status != NULL);
+
 	return status->mixrampdb;
 }
 
 float
 mpd_status_get_mixrampdelay(const struct mpd_status *status)
 {
+	assert(status != NULL);
+
 	return status->mixrampdelay;
 }
 
 int
 mpd_status_get_song_pos(const struct mpd_status *status)
 {
+	assert(status != NULL);
+
 	return status->song_pos;
 }
 
 int
 mpd_status_get_song_id(const struct mpd_status *status)
 {
+	assert(status != NULL);
+
 	return status->song_id;
 }
 
 int
 mpd_status_get_next_song_pos(const struct mpd_status *status)
 {
+	assert(status != NULL);
+
 	return status->next_song_pos;
 }
 
@@ -352,30 +387,40 @@ mpd_status_get_next_song_id(const struct mpd_status *status)
 unsigned
 mpd_status_get_elapsed_time(const struct mpd_status *status)
 {
+	assert(status != NULL);
+
 	return status->elapsed_time;
 }
 
 unsigned
 mpd_status_get_elapsed_ms(const struct mpd_status *status)
 {
+	assert(status != NULL);
+
 	return status->elapsed_ms;
 }
 
 unsigned
 mpd_status_get_total_time(const struct mpd_status *status)
 {
+	assert(status != NULL);
+
 	return status->total_time;
 }
 
 unsigned
 mpd_status_get_kbit_rate(const struct mpd_status *status)
 {
+	assert(status != NULL);
+
 	return status->kbit_rate;
 }
 
 const struct mpd_audio_format *
 mpd_status_get_audio_format(const struct mpd_status *status)
 {
+	assert(status != NULL);
+
 	return !mpd_audio_format_is_empty(&status->audio_format)
 		? &status->audio_format
 		: NULL;
@@ -384,11 +429,15 @@ mpd_status_get_audio_format(const struct mpd_status *status)
 unsigned
 mpd_status_get_update_id(const struct mpd_status *status)
 {
+	assert(status != NULL);
+
 	return status->update_id;
 }
 
 const char *
 mpd_status_get_error(const struct mpd_status *status)
 {
+	assert(status != NULL);
+
 	return status->error;
 }


### PR DESCRIPTION
Hello,
this series of commits address out of memory (OOM) events in some of libmpdclient functions.

96eb06f18034aa8e3279b14bee797b7f82d356f7: guard against an OOM event in `mpd_connection_new()`

e7c4c125d093f322f5219ee213a2693d605af4df: refactor internal functions of the settings API so that we can catch OOM events during the parse of host/password (`mpd_settings_new()`). Previously, some OOM events were silently ignored.

5c751a761ec9f71a43ee0e41cfff3208f31a58b8: adds asserts to debug builds for the song API

20866c98385b740a74f6f3fed4dfc7f86ebebb83: adds asserts to debug builds for the status API
