### PR TITLE
output: unveil OOM event in mpd_output_feed() via mpd_recv_output()

### DIFF
--- a/src/ioutput.h
+++ b/src/ioutput.h
@@ -1,0 +1,54 @@
+/* libmpdclient
+   (c) 2003-2019 The Music Player Daemon Project
+   This project's homepage is: http://www.musicpd.org
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   - Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   - Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef MPD_INTERNAL_OUTPUT_H
+#define MPD_INTERNAL_OUTPUT_H
+
+#include "kvlist.h"
+
+#include <stdbool.h>
+
+struct mpd_output {
+	unsigned id;
+	char *name;
+	char *plugin;
+
+	struct mpd_kvlist attributes;
+	/**
+	 * item preallocated to avoid triggering OOM where we cannot warn the
+	 * user (i.e. functions that return bool and do not receive the
+	 * connection object).
+	 *
+	 * This item is preallocated in mpd_recv_output().
+	 **/
+	struct mpd_kvlist_item *item_buf;
+
+	bool enabled;
+};
+
+#endif

--- a/src/kvlist.h
+++ b/src/kvlist.h
@@ -32,6 +32,7 @@
 #include <mpd/pair.h>
 #include <mpd/compiler.h>
 
+#include <stdbool.h>
 #include <stddef.h>
 
 struct mpd_kvlist {
@@ -47,9 +48,34 @@ mpd_kvlist_init(struct mpd_kvlist *l);
 void
 mpd_kvlist_deinit(struct mpd_kvlist *l);
 
-void
+bool
+mpd_kvlist_create_item(struct mpd_kvlist_item **i, const char *key,
+		       size_t key_length, const char *value);
+
+/**
+ * Do not use this function directly:
+ * 1. Call mpd_kvlist_add() if you want the function to internally allocate the
+ * kvlist item
+ * 2. Call mpd_kvlist_add_noalloc() if you already have allocated the item, and
+ * pass it via the item parameter
+ */
+bool
+mpd_kvlist_add_fn(struct mpd_kvlist *l, const char *key, size_t key_length,
+		  const char *value, struct mpd_kvlist_item *item);
+
+static inline bool
 mpd_kvlist_add(struct mpd_kvlist *l, const char *key, size_t key_length,
-	       const char *value);
+	       const char *value)
+{
+	return mpd_kvlist_add_fn(l, key, key_length, value, NULL);
+}
+
+static inline bool
+mpd_kvlist_add_noalloc(struct mpd_kvlist *l, const char *key, size_t key_length,
+		       const char *value, struct mpd_kvlist_item *item)
+{
+	return mpd_kvlist_add_fn(l, key, key_length, value, item);
+}
 
 mpd_pure
 const char *


### PR DESCRIPTION
Hello,
I've decided to seperate this commit from the previous series of OOM commits because of its complexity.
Here's the explanation from the commit itself:

The function `mpd_output_feed()` can trigger an OOM event due to its use
of `kvlist_add()` when parsing an output attribute. Unfortunately, there
is no way to communicate the user about the OOM event as
(i) the function already returns false when the next output has been
received;
(ii) the function does not have access to the `mpd_connection object` to record
the OOM event; and
(iii) we should not change its signature as all `mpd_*_feed()` functions
employ the same signature.

Thus, a new kvlist function has been created to preallocate items for
functions where libmpdclient can record the OOM event. This function is
used in `mpd_recv_output()` to preallocate items for `mpd_output_feed()`;
therefore, `mpd_output_feed()` does not trigger the aformentioned OOM
event.

There is a restrictions for this patch: we are unable to catch the OOM
event if the user employ `mpd_recv_pair_named()` directly (without
`mpd_recv_output()`.

Another (theoretical) restriction is that items are only preallocated
after the first call of `mpd_output_feed()` in `mpd_recv_output()`.
However, as items are exclusively used for attribute pairs and they are
sent at the end of the MPD response, no items are used for the first
call.

kvlist: create `mpd_kvlist_create_item()` to preallocate `mpd_kvlist_item`
output: expose (internally) the `mpd_output` object
output: preallocate items in `mpd_recv_output()` for `mpd_output_feed()`
calls

------------------------------------------------------------------------------------------------
(the following is not present in the commit message:)
My audio output (pulse audio) seems unable to accept output attributes (at least, from my testing and reading of the MPD code)
So, to test this commit, I've changed the pair received from MPD to force the use of attributes (i.e. changed `pair->name` to attribute and created a new `pair->value` to have the format `name=value`). This allowed me to test the functions proposed in this commit.

Best regards
