### PR TITLE
status: add support for "oneshot" single mode

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
 libmpdclient 2.18 (not yet released)
 * more out-of-memory checks
+* support MPD protocol 0.21
+ - "oneshot" single state
 
 libmpdclient 2.17 (2019/12/04)
 * search: add mpd_search_add_db_songs_to_playlist()

--- a/include/mpd/player.h
+++ b/include/mpd/player.h
@@ -38,6 +38,7 @@
 #define MPD_PLAYER_H
 
 #include "compiler.h"
+#include "status.h"
 
 #include <stdbool.h>
 
@@ -384,7 +385,45 @@ bool
 mpd_run_random(struct mpd_connection *connection, bool mode);
 
 /**
+ * Sets single state for the playlist.
+ * If state is #MPD_SINGLE_ON, MPD enables single mode: playback is stopped
+ * after current song, or song is repeated if the repeat mode is enabled.
+ *
+ * If state is #MPD_SINGLE_OFF, MPD disables single mode: if random mode is
+ * enabled, the playlist order is shuffled after it is played completely.
+ *
+ * If state is #MPD_SINGLE_ONESHOT, MPD enables single mode temporarily: single
+ * mode is disabled (#MPD_SINGLE_OFF) after a song has been played and there is
+ * another song in the current playlist.
+ *
+ * @param connection the connection to MPD
+ * @param state the desired single mode state
+ * @return true on success, false on error or state is #MPD_SINGLE_UNKNOWN
+ *
+ * @since MPD 0.21, libmpdclient 2.18.
+ */
+bool
+mpd_send_single_state(struct mpd_connection *connection,
+		      enum mpd_single_state state);
+
+/**
+ * Shortcut for mpd_send_single_state() and mpd_response_finish().
+ *
+ * @param connection the connection to MPD
+ * @param state the desired single mode state
+ * @return true on success, false on error or state is #MPD_SINGLE_UNKNOWN
+ *
+ * @since MPD 0.21, libmpdclient 2.18.
+ */
+bool
+mpd_run_single_state(struct mpd_connection *connection,
+		      enum mpd_single_state state);
+
+/**
  * Sets single mode on/off for the playlist.
+ * This function does not support the 'oneshot' state for single mode: use
+ * mpd_send_single_state() instead.
+ *
  * If mode is true, MPD enables single mode: playback is stopped after current
  * song, or song is repeated if the repeat mode is enabled.
  *

--- a/include/mpd/status.h
+++ b/include/mpd/status.h
@@ -60,6 +60,31 @@ enum mpd_state {
 	MPD_STATE_PAUSE = 3,
 };
 
+/**
+ * MPD's single state.
+ *
+ * @since libmpdclient 2.18, MPD 0.21.
+ */
+enum mpd_single_state {
+	/** disabled */
+	MPD_SINGLE_OFF = 0,
+
+	/** enabled */
+	MPD_SINGLE_ON,
+
+	/**
+	 * enables single state (#MPD_SINGLE_ONESHOT) for a single song, then
+	 * MPD disables single state (#MPD_SINGLE_OFF) if the current song
+	 * has played and there is another song in the current playlist
+	 *
+	 * @since MPD 0.21
+	 **/
+	MPD_SINGLE_ONESHOT,
+
+	/** Unknown state */
+	MPD_SINGLE_UNKNOWN,
+};
+
 struct mpd_connection;
 struct mpd_pair;
 struct mpd_audio_format;
@@ -148,7 +173,25 @@ bool
 mpd_status_get_random(const struct mpd_status *status);
 
 /**
- * Returns true if single mode is on.
+ * Returns the current state of single mode on MPD.
+ *
+ * If the state is #MPD_SINGLE_ONESHOT, MPD will transition to #MPD_SINGLE_OFF
+ * after a song is played and if there is another song in the queue. The
+ * #mpd_status object will not be updated accordingly. In this case, you need
+ * to call mpd_send_status() and mpd_recv_status() again.
+ *
+ * @since MPD 0.21, libmpdclient 2.18.
+ */
+mpd_pure
+enum mpd_single_state
+mpd_status_get_single_state(const struct mpd_status *status);
+
+/**
+ * This function is deprecated as it does not distinguish the states of
+ * the single mode (added to MPD 0.21). Call mpd_status_get_single_state() in
+ * its place.
+ *
+ * Returns true if single mode is either on or in oneshot.
  */
 mpd_pure
 bool

--- a/libmpdclient.ld
+++ b/libmpdclient.ld
@@ -204,6 +204,8 @@ global:
 	mpd_run_repeat;
 	mpd_send_random;
 	mpd_run_random;
+	mpd_send_single_state;
+	mpd_run_single_state;
 	mpd_send_single;
 	mpd_run_single;
 	mpd_send_consume;
@@ -379,6 +381,7 @@ global:
 	mpd_status_get_volume;
 	mpd_status_get_repeat;
 	mpd_status_get_random;
+	mpd_status_get_single_state;
 	mpd_status_get_single;
 	mpd_status_get_consume;
 	mpd_status_get_queue_length;

--- a/src/player.c
+++ b/src/player.c
@@ -267,24 +267,28 @@ mpd_run_random(struct mpd_connection *connection, bool mode)
 		mpd_response_finish(connection);
 }
 
+static const char *
+single_state_to_string(enum mpd_single_state state)
+{
+	switch (state) {
+	case MPD_SINGLE_OFF:
+		return "0";
+	case MPD_SINGLE_ON:
+		return "1";
+	case MPD_SINGLE_ONESHOT:
+		return "oneshot";
+	case MPD_SINGLE_UNKNOWN:
+		return NULL;
+	}
+	return NULL;
+}
 bool
 mpd_send_single_state(struct mpd_connection *connection,
 		      enum mpd_single_state state)
 {
-	char state_str[16];
-
-	switch (state) {
-	case MPD_SINGLE_OFF:
-	case MPD_SINGLE_ON:
-		snprintf(state_str, sizeof(state_str), "%u",
-			 (unsigned int)state);
-		break;
-	case MPD_SINGLE_ONESHOT:
-		snprintf(state_str, sizeof(state_str), "oneshot");
-		break;
-	case MPD_SINGLE_UNKNOWN:
+	const char *state_str = single_state_to_string(state);
+	if (state_str == NULL)
 		return false;
-	}
 
 	return mpd_send_command(connection, "single", state_str, NULL);
 }

--- a/src/player.c
+++ b/src/player.c
@@ -268,6 +268,37 @@ mpd_run_random(struct mpd_connection *connection, bool mode)
 }
 
 bool
+mpd_send_single_state(struct mpd_connection *connection,
+		      enum mpd_single_state state)
+{
+	char state_str[16];
+
+	switch (state) {
+	case MPD_SINGLE_OFF:
+	case MPD_SINGLE_ON:
+		snprintf(state_str, sizeof(state_str), "%u",
+			 (unsigned int)state);
+		break;
+	case MPD_SINGLE_ONESHOT:
+		snprintf(state_str, sizeof(state_str), "oneshot");
+		break;
+	case MPD_SINGLE_UNKNOWN:
+		return false;
+	}
+
+	return mpd_send_command(connection, "single", state_str, NULL);
+}
+
+bool
+mpd_run_single_state(struct mpd_connection *connection,
+		      enum mpd_single_state state)
+{
+	return mpd_run_check(connection) &&
+		mpd_send_single_state(connection, state) &&
+		mpd_response_finish(connection);
+}
+
+bool
 mpd_send_single(struct mpd_connection *connection, bool mode)
 {
 	return mpd_send_int_command(connection, "single", mode);


### PR DESCRIPTION
Support "oneshot" single mode in libmpdclient 2.18. Oneshot allows MPD to
transition automatically from "on" to "off" if the current song has
finished and another song is present in the current playlist.