### PR TITLE
Support rangeid command + fix version restrictions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,8 @@
 libmpdclient 2.19 (not yet released)
 * support MPD protocol 0.16
  - replay gain
+* support MPD protocol 0.20
+ - rangeid
 
 libmpdclient 2.18 (2020/01/20)
 * more out-of-memory checks

--- a/include/mpd/output.h
+++ b/include/mpd/output.h
@@ -277,7 +277,7 @@ mpd_run_output_set(struct mpd_connection *connection, unsigned output_id,
  * @param output_name the name of the output to be moved
  * @return true on success
  *
- * @since libmpdclient 2.18
+ * @since libmpdclient 2.18, MPD 0.22.
  */
 bool
 mpd_send_move_output(struct mpd_connection *connection,
@@ -290,7 +290,7 @@ mpd_send_move_output(struct mpd_connection *connection,
  * @param output_name the name of the output to be moved
  * @return true on success
  *
- * @since libmpdclient 2.18
+ * @since libmpdclient 2.18, MPD 0.22.
  */
 bool
 mpd_run_move_output(struct mpd_connection *connection,

--- a/include/mpd/partition.h
+++ b/include/mpd/partition.h
@@ -114,7 +114,7 @@ mpd_run_newpartition(struct mpd_connection *connection, const char *partition);
  * @param partition the partition name
  * @return true on success
  *
- * @since libmpdclient 2.18
+ * @since libmpdclient 2.18, MPD 0.22
  */
 bool
 mpd_send_delete_partition(struct mpd_connection *connection,
@@ -127,7 +127,7 @@ mpd_send_delete_partition(struct mpd_connection *connection,
  * @param partition the partition name
  * @return true on success
  *
- * @since libmpdclient 2.18
+ * @since libmpdclient 2.18, MPD 0.22
  */
 bool
 mpd_run_delete_partition(struct mpd_connection *connection,

--- a/include/mpd/queue.h
+++ b/include/mpd/queue.h
@@ -714,6 +714,29 @@ bool
 mpd_run_prio_id(struct mpd_connection *connection, int priority,
 		unsigned id);
 
+/**
+ * Specify the portion of a song that shall be played.
+ * The song is identified by its id and cannot be the currently playing song.
+ *
+ * The start/end values are offsets in seconds (fractional seconds allowed);
+ * both are optional.
+ *
+ * @param id the id of the song (cannot be the currently playing song)
+ * @param start the offset in seconds for starting the song; the special value
+ * "0.0" makes the start of the range open
+ * @param end the offset in seconds for ending the song; the special value
+ * "0.0" makes the end of the range open
+ * @return true on success, false on error
+ *
+ * @since libmpdclient 2.19, MPD 0.19
+ */
+bool
+mpd_send_range_id(struct mpd_connection *connection, unsigned id,
+		  float start, float end);
+
+bool
+mpd_run_range_id(struct mpd_connection *connection, unsigned id,
+		  float start, float end);
 #ifdef __cplusplus
 }
 #endif

--- a/include/mpd/queue.h
+++ b/include/mpd/queue.h
@@ -728,15 +728,28 @@ mpd_run_prio_id(struct mpd_connection *connection, int priority,
  * "0.0" makes the end of the range open
  * @return true on success, false on error
  *
- * @since libmpdclient 2.19, MPD 0.19
+ * @since libmpdclient 2.19, MPD 0.20
  */
 bool
 mpd_send_range_id(struct mpd_connection *connection, unsigned id,
 		  float start, float end);
 
+/**
+ *
+ * Shortcut for mpd_send_range_id() and mpd_response_finish().
+ *
+ * @param id the id of the song (cannot be the currently playing song)
+ * @param start the offset in seconds for starting the song; the special value
+ * "0.0" makes the start of the range open
+ * @param end the offset in seconds for ending the song; the special value
+ * "0.0" makes the end of the range open
+ * @return true on success, false on error
+ *
+ * @since libmpdclient 2.19, MPD 0.20
+ */
 bool
 mpd_run_range_id(struct mpd_connection *connection, unsigned id,
-		  float start, float end);
+		 float start, float end);
 #ifdef __cplusplus
 }
 #endif

--- a/include/mpd/queue.h
+++ b/include/mpd/queue.h
@@ -722,34 +722,34 @@ mpd_run_prio_id(struct mpd_connection *connection, int priority,
  * both are optional.
  *
  * @param id the id of the song (cannot be the currently playing song)
- * @param start the offset in seconds for starting the song; the special value
- * "0.0" makes the start of the range open
- * @param end the offset in seconds for ending the song; the special value
- * "0.0" makes the end of the range open
+ * @param start_ms the offset in milliseconds for starting the song; the special
+ * value "UINT_MAX" makes the start of the range open
+ * @param end-Ms the offset in milliseconds for ending the song; the special
+ * value "UINT_MAX" makes the end of the range open
  * @return true on success, false on error
  *
  * @since libmpdclient 2.19, MPD 0.20
  */
 bool
 mpd_send_range_id(struct mpd_connection *connection, unsigned id,
-		  float start, float end);
+		  unsigned start_ms, unsigned end_ms);
 
 /**
  *
  * Shortcut for mpd_send_range_id() and mpd_response_finish().
  *
  * @param id the id of the song (cannot be the currently playing song)
- * @param start the offset in seconds for starting the song; the special value
- * "0.0" makes the start of the range open
- * @param end the offset in seconds for ending the song; the special value
- * "0.0" makes the end of the range open
+ * @param start_ms the offset in milliseconds for starting the song; the special
+ * value "UINT_MAX" makes the start of the range open
+ * @param end_ms the offset in milliseconds for ending the song; the special
+ * value "UINT_MAX" makes the end of the range open
  * @return true on success, false on error
  *
  * @since libmpdclient 2.19, MPD 0.20
  */
 bool
 mpd_run_range_id(struct mpd_connection *connection, unsigned id,
-		 float start, float end);
+		 unsigned start_ms, unsigned end_ms);
 #ifdef __cplusplus
 }
 #endif

--- a/include/mpd/replay_gain.h
+++ b/include/mpd/replay_gain.h
@@ -48,7 +48,7 @@ struct mpd_connection;
 /**
  * MPD's replay gain mode.
  *
- * @since libmpdclient 2.18, MPD 0.16.
+ * @since libmpdclient 2.19, MPD 0.16.
  */
 enum mpd_replay_gain_mode {
 	/** ignore ReplayGain tag values */
@@ -91,7 +91,7 @@ mpd_parse_replay_gain_name(const char *name);
  * @param connection the connection to MPD
  * @return true on success, false on error
  *
- * @since MPD 0.16, libmpdclient 2.18.
+ * @since MPD 0.16, libmpdclient 2.19.
  */
 bool
 mpd_send_replay_gain_status(struct mpd_connection *connection);
@@ -104,7 +104,7 @@ mpd_send_replay_gain_status(struct mpd_connection *connection);
  * @return #mpd_replay_gain_mode object: #MPD_REPLAY_UNKNOWN on error (or
  * unknown ReplayGain mode); other modes on success.
  *
- * @since MPD 0.16, libmpdclient 2.18.
+ * @since MPD 0.16, libmpdclient 2.19.
  */
 enum mpd_replay_gain_mode
 mpd_run_replay_gain_status(struct mpd_connection *connection);
@@ -116,7 +116,7 @@ mpd_run_replay_gain_status(struct mpd_connection *connection);
  * @param mode the desired replay gain mode
  * @return true on success, false on error
  *
- * @since MPD 0.16, libmpdclient 2.18.
+ * @since MPD 0.16, libmpdclient 2.19.
  */
 bool
 mpd_send_replay_gain_mode(struct mpd_connection *connection,
@@ -129,7 +129,7 @@ mpd_send_replay_gain_mode(struct mpd_connection *connection,
  * @mode mode the desired replay gain mode
  * @return true on success, false on error
  *
- * @since MPD 0.16, libmpdclient 2.18.
+ * @since MPD 0.16, libmpdclient 2.19.
  */
 bool
 mpd_run_replay_gain_mode(struct mpd_connection *connection,

--- a/libmpdclient.ld
+++ b/libmpdclient.ld
@@ -303,6 +303,8 @@ global:
 	mpd_run_prio_range;
 	mpd_send_prio_id;
 	mpd_run_prio_id;
+	mpd_send_range_id;
+	mpd_run_range_id;
 
 	/* mpd/recv.h */
 	mpd_recv_pair;

--- a/src/isend.h
+++ b/src/isend.h
@@ -103,9 +103,9 @@ mpd_send_range_u_command(struct mpd_connection *connection,
 			 const char *command,
 			 unsigned start, unsigned end, unsigned arg2);
 bool
-mpd_send_u_frange_command(struct mpd_connection *connection,
-			  const char *command, unsigned arg1,
-			  float start, float end);
+mpd_send_u_millirange_command(struct mpd_connection *connection,
+			      const char *command, unsigned arg1,
+			      unsigned start_ms, unsigned end_ms);
 
 bool
 mpd_send_ll_command(struct mpd_connection *connection, const char *command,

--- a/src/isend.h
+++ b/src/isend.h
@@ -102,6 +102,10 @@ bool
 mpd_send_range_u_command(struct mpd_connection *connection,
 			 const char *command,
 			 unsigned start, unsigned end, unsigned arg2);
+bool
+mpd_send_u_frange_command(struct mpd_connection *connection,
+			  const char *command, unsigned arg1,
+			  float start, float end);
 
 bool
 mpd_send_ll_command(struct mpd_connection *connection, const char *command,

--- a/src/queue.c
+++ b/src/queue.c
@@ -500,3 +500,19 @@ mpd_run_prio_id(struct mpd_connection *connection, int priority,
 		mpd_send_prio_id(connection, priority, id) &&
 		mpd_response_finish(connection);
 }
+
+bool
+mpd_send_range_id(struct mpd_connection *connection, unsigned id,
+		  float start, float end)
+{
+	return mpd_send_u_frange_command(connection, "rangeid", id, start, end);
+}
+
+bool
+mpd_run_range_id(struct mpd_connection *connection, unsigned id,
+		 float start, float end)
+{
+	return mpd_run_check(connection) &&
+		mpd_send_range_id(connection, id, start, end) &&
+		mpd_response_finish(connection);
+}

--- a/src/queue.c
+++ b/src/queue.c
@@ -503,16 +503,17 @@ mpd_run_prio_id(struct mpd_connection *connection, int priority,
 
 bool
 mpd_send_range_id(struct mpd_connection *connection, unsigned id,
-		  float start, float end)
+		  unsigned int start_ms, unsigned int end_ms)
 {
-	return mpd_send_u_frange_command(connection, "rangeid", id, start, end);
+	return mpd_send_u_millirange_command(connection, "rangeid", id,
+					     start_ms, end_ms);
 }
 
 bool
 mpd_run_range_id(struct mpd_connection *connection, unsigned id,
-		 float start, float end)
+		 unsigned int start_ms, unsigned int end_ms)
 {
 	return mpd_run_check(connection) &&
-		mpd_send_range_id(connection, id, start, end) &&
+		mpd_send_range_id(connection, id, start_ms, end_ms) &&
 		mpd_response_finish(connection);
 }

--- a/src/send.c
+++ b/src/send.c
@@ -53,6 +53,20 @@ format_range(char *buffer, size_t size, unsigned start, unsigned end)
 		snprintf(buffer, size, "%u:%u", start, end);
 }
 
+static void
+format_frange(char *buffer, size_t size, float start, float end)
+{
+	/* the special value 0.0 means "open range" */
+	if (start == 0.0 && end == 0.0)
+		snprintf(buffer, size, ":");
+	else if (start == 0.0)
+		snprintf(buffer, size, ":%f", end);
+	else if (end == 0.0)
+		snprintf(buffer, size, "%f:", start);
+	else
+		snprintf(buffer, size, "%f:%f", start, end);
+}
+
 /**
  * Checks whether it is possible to send a command now.
  */
@@ -278,6 +292,21 @@ mpd_send_range_u_command(struct mpd_connection *connection,
 	snprintf(arg2_string, sizeof(arg2_string), "%i", arg2);
 	return mpd_send_command(connection, command,
 				arg1_string, arg2_string, NULL);
+}
+
+bool
+mpd_send_u_frange_command(struct mpd_connection *connection,
+			 const char *command, unsigned arg1,
+			 float start, float end)
+{
+	/* <start>:<end> */
+	char range_string[FLOATLEN * 2 + 1 + 1];
+	char arg1_string[INTLEN + 1];
+
+	snprintf(arg1_string, sizeof(arg1_string), "%u", arg1);
+	format_frange(range_string, sizeof(range_string), start, end);
+	return mpd_send_command(connection, command,
+				arg1_string, range_string, NULL);
 }
 
 bool


### PR DESCRIPTION
Hello Max Kellerman,
1. https://github.com/MusicPlayerDaemon/libmpdclient/commit/a709dfcd3645b440bb52b0b8d81cb840da2d38cc and https://github.com/MusicPlayerDaemon/libmpdclient/commit/b850b18fa77144182e95bf5fc21acdf47b0660e9 adds support for the "rangeid" command from MPD 0.20.
I've used the value _0.0_ for allowing the user to have an open range
other possibilities would be **HUGE_VAL** (pre-C99), **INFINITY** (ISO C99) or **NAN** (ISO C99) from `math.h`
let me know if you prefer something else

2. https://github.com/MusicPlayerDaemon/libmpdclient/commit/e537a8e012086c7b7fff83e84a978ea4e96b61fa fixes some version restrictions
replay_gain has been delayed to libmpdclient 2.19.
"move_output" and "delete partition" requires MPD 0.22
