### PR TITLE
buffer: refactor buffer to be dynamically-sized

### DIFF
--- a/src/buffer.h
+++ b/src/buffer.h
@@ -32,10 +32,10 @@
 #include <assert.h>
 #include <string.h>
 #include <stdbool.h>
+#include <stdlib.h>
 
 /**
- * A fixed 4kB buffer which can be appended at the end, and consumed
- * at the beginning.
+ * A buffer which can be appended at the end, and consumed at the beginning.
  */
 struct mpd_buffer {
 	/** the next buffer position to write to */
@@ -45,17 +45,37 @@ struct mpd_buffer {
 	unsigned read;
 
 	/** the actual buffer */
-	unsigned char data[4096];
+	unsigned char *data;
+
+	/** size of buffer */
+	size_t data_len;
 };
 
 /**
  * Initialize an empty buffer.
  */
-static inline void
+static inline void *
 mpd_buffer_init(struct mpd_buffer *buffer)
 {
+	const size_t std_data_len = 4096;
+
 	buffer->read = 0;
 	buffer->write = 0;
+	buffer->data_len = std_data_len;
+	buffer->data = malloc(buffer->data_len);
+	if (buffer->data != NULL)
+		memset(buffer->data, 0, buffer->data_len);
+
+	return buffer->data;
+}
+
+/**
+ * Free the buffer area.
+ */
+static inline void
+mpd_buffer_end(struct mpd_buffer *buffer)
+{
+	free(buffer->data);
 }
 
 /**
@@ -79,11 +99,12 @@ mpd_buffer_move(struct mpd_buffer *buffer)
 static inline size_t
 mpd_buffer_room(const struct mpd_buffer *buffer)
 {
-	assert(buffer->write <= sizeof(buffer->data));
+	assert(buffer->write <= buffer->data_len);
 	assert(buffer->read <= buffer->write);
 
-	return sizeof(buffer->data) - (buffer->write - buffer->read);
+	return buffer->data_len - (buffer->write - buffer->read);
 }
+
 
 /**
  * Checks if the buffer is full, i.e. nothing can be written.
@@ -125,7 +146,7 @@ mpd_buffer_expand(struct mpd_buffer *buffer, size_t nbytes)
 static inline size_t
 mpd_buffer_size(const struct mpd_buffer *buffer)
 {
-	assert(buffer->write <= sizeof(buffer->data));
+	assert(buffer->write <= buffer->data_len);
 	assert(buffer->read <= buffer->write);
 
 	return buffer->write - buffer->read;
@@ -152,6 +173,52 @@ mpd_buffer_consume(struct mpd_buffer *buffer, size_t nbytes)
 	assert(nbytes <= mpd_buffer_size(buffer));
 
 	buffer->read += nbytes;
+}
+
+/**
+ * Makes at least min_size bytes available for writing data.
+ * In other words, mpd_buffer_room() will be >= min_size if called after this
+ * function.
+ */
+static inline bool
+mpd_buffer_make_room(struct mpd_buffer *buffer, size_t min_avail_len)
+{
+	size_t newsize;
+
+	if (mpd_buffer_room(buffer) >= min_avail_len)
+		return true;
+
+	newsize = buffer->data_len * 2;
+	while (newsize < min_avail_len)
+		newsize *= 2;
+
+	/* empty buffer */
+	if (mpd_buffer_room(buffer) == buffer->data_len) {
+		free(buffer->data);
+		buffer->data = malloc(newsize);
+		if (buffer->data == NULL)
+			return false;
+		memset(buffer->data, 0, newsize);
+	} else {
+		buffer->data = realloc(buffer->data, newsize);
+		if (buffer->data == NULL)
+			return false;
+
+		/* clear region not committed and new region */
+		memset(mpd_buffer_write(buffer), 0,
+		       newsize - (buffer->data_len - mpd_buffer_room(buffer)));
+	}
+	buffer->data_len = newsize;
+	return true;
+}
+
+/**
+ * Double the buffer area.
+ */
+static inline bool
+mpd_buffer_double_buffer_size(struct mpd_buffer *buffer)
+{
+	return mpd_buffer_make_room(buffer, buffer->data_len * 2);
 }
 
 #endif

--- a/src/sync.c
+++ b/src/sync.c
@@ -100,27 +100,7 @@ bool
 mpd_sync_send_command_v(struct mpd_async *async, const struct timeval *tv0,
 			const char *command, va_list args)
 {
-	struct timeval tv, *tvp;
-	va_list copy;
-	bool success;
-
-	if (tv0 != NULL) {
-		tv = *tv0;
-		tvp = &tv;
-	} else
-		tvp = NULL;
-
-	while (true) {
-		va_copy(copy, args);
-		success = mpd_async_send_command_v(async, command, copy);
-		va_end(copy);
-
-		if (success)
-			return true;
-
-		if (!mpd_sync_io(async, tvp))
-			return false;
-	}
+	return mpd_async_send_command_v(async, command, args);
 }
 
 bool


### PR DESCRIPTION
Allow the internal buffer of libmpdclient to grow dynamically in size
as needed by mpd_{async/sync}_send_command.
Previously, the buffer was limited to 4KiB.

Address issue reported downstream by Debian[1] and upstream by kaliko
(@mxjeff)[2]
[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=953110
[2] https://github.com/MusicPlayerDaemon/libmpdclient/issues/51
---
Hello,
this is a solution to issue #51. It requires refactoring the buffer source code.
I will provide another solution in case you want to stick with the hardcoded limit.