### PR TITLE
buffer: identify messages with length over the buffer limit

### DIFF
--- a/src/async.c
+++ b/src/async.c
@@ -129,6 +129,20 @@ mpd_async_copy_error(const struct mpd_async *async,
 	return mpd_error_copy(dest, &async->error);
 }
 
+bool
+mpd_async_set_error(struct mpd_async *async, enum mpd_error error,
+		    const char *error_message)
+{
+	assert(async != NULL);
+
+	if (mpd_error_is_defined(&async->error))
+		return false;
+
+	mpd_error_code(&async->error, error);
+	mpd_error_message(&async->error, error_message);
+	return true;
+}
+
 int
 mpd_async_get_fd(const struct mpd_async *async)
 {

--- a/src/iasync.h
+++ b/src/iasync.h
@@ -44,4 +44,15 @@ bool
 mpd_async_copy_error(const struct mpd_async *async,
 		     struct mpd_error_info *dest);
 
+/**
+ * Sets the object's error condition.
+ *
+ * @return true if there was no error in #async, false if an error
+ * condition is stored in #async; the #error is only set if there was no error
+ * previously present
+ */
+bool
+mpd_async_set_error(struct mpd_async *async, enum mpd_error error,
+		    const char *error_message);
+
 #endif

--- a/src/sync.c
+++ b/src/sync.c
@@ -116,15 +116,18 @@ mpd_sync_send_command_v(struct mpd_async *async, const struct timeval *tv0,
 		success = mpd_async_send_command_v(async, command, copy);
 		va_end(copy);
 
-		/* no characters were written to async buffer */
+		if (success)
+			return true;
+
+		/* no characters were written to async buffer
+		 * and no space will be made available with mpd_sync_io()
+		 * hence we do not have enough space */
 		if ((mpd_async_events(async) & MPD_ASYNC_EVENT_WRITE) == 0) {
 			(void)mpd_async_set_error(async, MPD_ERROR_OOM,
 					"Not enough buffer space for message");
 			return false;
 		}
 
-		if (success)
-			return true;
 
 		if (!mpd_sync_io(async, tvp))
 			return false;


### PR DESCRIPTION
Identify messages that are over the 4KiB buffer limit

Address issue reported downstream by Debian[1] and upstream by kaliko
(@mxjeff)[2]
[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=953110
[2] https://github.com/MusicPlayerDaemon/libmpdclient/issues/51
-----
Conservative solution for issue #51.

The output is thus:
`--> mpc find '('$(for i in $(seq 1 4091); do echo -n "+"; done)')'`
`MPD error: Not enough buffer space for message`
