### PR TITLE
settings: fix off-by-one write in hostname

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -86,7 +86,7 @@ mpd_parse_host_password(struct mpd_settings *settings)
 	}
 
 	memcpy(settings->host, &oldhost[at_pos + 1], host_len - 1);
-	settings->host[host_len] = 0;
+	settings->host[host_len - 1] = 0;
 	free(oldhost);
 	return true;
 }


### PR DESCRIPTION
Fix off-by-one write in hostname for mpd_parse_host_password()

Address issue reported by Leo Nikkila (@Inikkila) [1]
[1] https://github.com/MusicPlayerDaemon/libmpdclient/issues/52