### PR TITLE
Add missing API doc for libmpdclient 2.19 functions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@ libmpdclient 2.20 (not yet released)
 libmpdclient 2.19 (2020/07/03)
 * fix off-by-one bug in MPD_HOST parser
 * add function mpd_lookup_replay_gain_mode()
+* playlist: add function mpd_run_playlist_move()
 * identify messages with length over the buffer limit
 * support MPD protocol 0.16
  - replay gain

--- a/include/mpd/idle.h
+++ b/include/mpd/idle.h
@@ -52,6 +52,8 @@ struct mpd_connection;
  * @since libmpdclient 2.5 added support for #MPD_IDLE_STICKER,
  * #MPD_IDLE_SUBSCRIPTION and #MPD_IDLE_MESSAGE.
  * @since libmpdclient 2.17 added support for #MPD_IDLE_PARTITION.
+ * @since libmpdclient 2.19 added support for #MPD_IDLE_NEIGHBOR,
+ * #MPD_IDLE_MOUNT
  */
 enum mpd_idle {
 	/** song database has been updated */

--- a/include/mpd/playlist.h
+++ b/include/mpd/playlist.h
@@ -226,6 +226,8 @@ mpd_send_playlist_move(struct mpd_connection *connection, const char *name,
  * @param from previous song place in the playlist
  * @param to next song position in the playlist
  * @return true on success, false on error
+ *
+ * @since libmpdclient 2.19
  */
 bool
 mpd_run_playlist_move(struct mpd_connection *connection, const char *name,

--- a/include/mpd/replay_gain.h
+++ b/include/mpd/replay_gain.h
@@ -85,6 +85,8 @@ mpd_parse_replay_gain_name(const char *name);
  * Looks up the name of the specified replay gain mode.
  *
  * @return the name, or NULL if the replay gain mode is not valid
+ *
+ * @since libmpdclient 2.19.
  */
 mpd_pure
 const char *


### PR DESCRIPTION
Hello,
this minor patch identifies libmpdclient version requirement for newly added functions to version 2.19