### PR TITLE
Make buffer size configurable at compile time and set it to 8192

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,7 @@ libmpdclient 2.20 (not yet released)
   - albumart
 * support tags "ComposerSort", "Ensemble", "Movement",
   "MovementNumber", "Location"
+* configurable buffer size, increase default from 4096 to 8192
 
 libmpdclient 2.19 (2020/07/03)
 * fix off-by-one bug in MPD_HOST parser

--- a/meson.build
+++ b/meson.build
@@ -21,6 +21,8 @@ conf.set('DEFAULT_PORT', get_option('default_port'))
 
 conf.set('HAVE_STRNDUP', cc.has_function('strndup', prefix: '#define _GNU_SOURCE\n#include <string.h>'))
 
+conf.set('BUFFER_SIZE', get_option('buffer_size'))
+
 platform_deps = []
 if host_machine.system() == 'haiku'
   platform_deps = [cc.find_library('network')]

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -21,3 +21,7 @@ option('documentation', type: 'boolean',
 option('test', type: 'boolean',
   value: false,
   description: 'Enable unit tests')
+
+option('buffer_size', type: 'string',
+  value: '8192',
+  description: 'response buffer size')

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -29,6 +29,8 @@
 #ifndef MPD_BUFFER_H
 #define MPD_BUFFER_H
 
+#include "config.h"
+
 #include <assert.h>
 #include <string.h>
 #include <stdbool.h>
@@ -45,7 +47,7 @@ struct mpd_buffer {
 	unsigned read;
 
 	/** the actual buffer */
-	unsigned char data[4096];
+	unsigned char data[BUFFER_SIZE];
 };
 
 /**


### PR DESCRIPTION
edit: I notified meanwhile the default mpd output buffer is 8 MiB not 8 kiB

The libmpdclient buffer is the max length of a output line and this is not limited on server side?

But eventually this patch is even so useful?

Or I struggling with all of this?