### PR TITLE
Replace meson.source_root() with meson.project_source_root()

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,6 +1,6 @@
 dconf = configuration_data()
 dconf.set('VERSION', meson.project_version())
-dconf.set('abs_top_srcdir', meson.source_root())
+dconf.set('abs_top_srcdir', project_root)
 
 if find_program('dot', required: false).found()
   dconf.set('HAVE_DOT', 'YES')

--- a/meson.build
+++ b/meson.build
@@ -7,6 +7,7 @@ project('libmpdclient', 'c', version: '2.21',
 )
 
 cc = meson.get_compiler('c')
+project_root = meson.current_source_dir()
 
 conf = configuration_data()
 conf.set_quoted('PACKAGE', meson.project_name())
@@ -73,7 +74,7 @@ test_ldflags = [
 ]
 
 if host_machine.system() == 'linux'
-  test_ldflags += [ '-Wl,--version-script=' + join_paths(meson.source_root(), 'libmpdclient.ld') ]
+  test_ldflags += [ '-Wl,--version-script=' + join_paths(project_root, 'libmpdclient.ld') ]
 endif
 
 if meson.version().version_compare('>=0.46.0')


### PR DESCRIPTION
When building libmpdclient as a subproject, using the function `meson.source_root()` will return the path of the global source root directory instead of the subproject source root directory. Using `meson.project_source_root()` will produce the correct behavior. Also, `meson.source_root()` has been [deprecated in Meson version 0.56.0](https://mesonbuild.com/Reference-manual_builtin_meson.html#mesonsource_root).

**Note:** This commit bumps the required minimum Meson version to 0.56.0. If this isn't acceptable for the project at this time, it could be changed to conditionally use this function depending on the Meson version being used ([like the current build defintion does for `compiler.has_link_argument()`](https://github.com/MusicPlayerDaemon/libmpdclient/blob/e67883d9a07a7d3cf760bfd24f5391d476e66e7d/meson.build#L79-L89)).