### PR TITLE
Clarified documentation for albumart/readpicture commands

### DIFF
--- a/include/mpd/albumart.h
+++ b/include/mpd/albumart.h
@@ -64,8 +64,8 @@ mpd_send_albumart(struct mpd_connection *connection, const char *uri, unsigned o
  * Receives the "albumart" response
  *
  * @param connection a valid and connected #mpd_connection
- * @param buffer an already allocated buffer, should be of the same size as the binary
- * chunk size (default 8192, can be set with binarylimit command)
+ * @param buffer an already allocated buffer, the size must be the same or greater than
+ * the binary chunk size (default 8192, can be set with binarylimit command)
  * @param buffer_size the size of the allocated buffer
  * @return read size on success, -1 on failure
  *
@@ -81,8 +81,8 @@ mpd_recv_albumart(struct mpd_connection *connection, void *buffer, size_t buffer
  * @param connection a valid and connected #mpd_connection
  * @param uri the URI of the song
  * @param offset to read from
- * @param buffer an already allocated buffer, should be of the same size as the binary
- * chunk size (default 8192, can be set with binarylimit command)
+ * @param buffer an already allocated buffer, the size must be the same or greater than
+ * the binary chunk size (default 8192, can be set with binarylimit command)
  * @param buffer_size the size of the allocated buffer
  * @return read size on success, -1 on failure
  *

--- a/include/mpd/readpicture.h
+++ b/include/mpd/readpicture.h
@@ -64,8 +64,8 @@ mpd_send_readpicture(struct mpd_connection *connection, const char *uri, unsigne
  * Receives the "readpicture" response
  *
  * @param connection a valid and connected #mpd_connection
- * @param buffer an already allocated buffer, should be of the same size as the binary
- * chunk size (default 8192, can be set with binarylimit command)
+ * @param buffer an already allocated buffer, the size must be the same or greater than
+ * the binary chunk size (default 8192, can be set with binarylimit command)
  * @param buffer_size the size of the allocated buffer
  * @return read size on success, -1 on failure
  *
@@ -81,8 +81,8 @@ mpd_recv_readpicture(struct mpd_connection *connection, void *buffer, size_t buf
  * @param connection a valid and connected #mpd_connection
  * @param uri the URI of the song
  * @param offset to read from
- * @param buffer an already allocated buffer, should be of the same size as the binary
- * chunk size (default 8192, can be set with binarylimit command)
+ * @param buffer an already allocated buffer, the size must be the same or greater than
+ * the binary chunk size (default 8192, can be set with binarylimit command)
  * @param buffer_size the size of the allocated buffer
  * @return read size on success, -1 on failure
  *


### PR DESCRIPTION
This PR modifies the language of the albumart/readpicture command comments to state that it's a requirement of the command to have a buffer size at least equal to the binary limit.

Ran into a documentation issue for the `albumart` and `readpicture` commands that blocked me for a few hours. Namely if you provide a buffer that's smaller than the binary limit, the return value from `mpd_recv_albumart`, `mpd_run_albumart`, `mpd_recv_readpicture`, and `mpd_run_readpicture` will be `-1`. The functions seem to respond correctly if the buffer size is greater than the binary limit.

While I suspect there's an underlying code issue, I'm unfamiliar with the layers of MPD and libmpdclient to figure out where it exists. I don't think I missed any spots, please let me know if there's any changes/wording/grammar/etc that needs adjusting. Modifying the documentation should help prevent the next person from spending too much time trying to figure this out. 

Thanks
