### PR TITLE
Adds more information to parse corresponding to the satellite cue fix pr in MPD repository

### DIFF
--- a/include/mpd/song.h
+++ b/include/mpd/song.h
@@ -101,6 +101,15 @@ mpd_song_get_tag(const struct mpd_song *song,
 		 enum mpd_tag_type type, unsigned idx);
 
 /**
+ * Returns the "real" URI of the song, the one to be used for opening
+ * the resource. If this attribute is nullptr, then #mpd_song_get_uri
+ * shall be used.
+ */
+mpd_pure
+const char *
+mpd_song_get_real_uri(const struct mpd_song *song);
+
+/**
  * Returns the duration of this song in seconds.  0 means the duration
  * is unknown.
  */

--- a/include/mpd/song.h
+++ b/include/mpd/song.h
@@ -138,6 +138,14 @@ unsigned
 mpd_song_get_start(const struct mpd_song *song);
 
 /**
+ * Returns the start of the virtual song within the physical file in
+ * milliseconds.
+ */
+mpd_pure
+unsigned
+mpd_song_get_start_ms(const struct mpd_song *song);
+
+/**
  * Returns the end of the virtual song within the physical file in
  * seconds. 0 means that the physical song file is played to the end.
  *
@@ -146,6 +154,14 @@ mpd_song_get_start(const struct mpd_song *song);
 mpd_pure
 unsigned
 mpd_song_get_end(const struct mpd_song *song);
+
+/**
+ * Returns the end of the virtual song within the physical file in
+ * milliseconds. 0 means that the physical song file is played to the end.
+ */
+mpd_pure
+unsigned
+mpd_song_get_end_ms(const struct mpd_song *song);
 
 /**
  * @return the POSIX UTC time stamp of the last modification, or 0 if

--- a/libmpdclient.ld
+++ b/libmpdclient.ld
@@ -366,7 +366,9 @@ global:
 	mpd_song_get_duration;
 	mpd_song_get_duration_ms;
 	mpd_song_get_start;
+	mpd_song_get_start_ms;
 	mpd_song_get_end;
+	mpd_song_get_end_ms;
 	mpd_song_get_last_modified;
 	mpd_song_set_pos;
 	mpd_song_get_pos;

--- a/libmpdclient.ld
+++ b/libmpdclient.ld
@@ -362,6 +362,7 @@ global:
 	mpd_song_dup;
 	mpd_song_get_uri;
 	mpd_song_get_tag;
+	mpd_song_get_real_uri;
 	mpd_song_get_duration;
 	mpd_song_get_duration_ms;
 	mpd_song_get_start;

--- a/src/song.c
+++ b/src/song.c
@@ -79,11 +79,24 @@ struct mpd_song {
 	unsigned start;
 
 	/**
+	 * Start of the virtual song within the physical file in
+	 * milliseconds.
+	 */
+	unsigned start_ms;
+
+	/**
 	 * End of the virtual song within the physical file in
 	 * seconds.  Zero means that the physical song file is
 	 * played to the end.
 	 */
 	unsigned end;
+
+	/**
+	 * End of the virtual song within the physical file in
+	 * milliseconds.  Zero means that the physical song
+	 * file is played to the end.
+	 */
+	unsigned end_ms;
 
 	/**
 	 * The POSIX UTC time stamp of the last modification, or 0 if
@@ -147,7 +160,9 @@ mpd_song_new(const char *uri)
 	song->duration = 0;
 	song->duration_ms = 0;
 	song->start = 0;
+	song->start_ms = 0;
 	song->end = 0;
+	song->end_ms = 0;
 	song->last_modified = 0;
 	song->pos = 0;
 	song->id = 0;
@@ -230,7 +245,9 @@ mpd_song_dup(const struct mpd_song *song)
 	ret->duration = song->duration;
 	ret->duration_ms = song->duration_ms;
 	ret->start = song->start;
+	ret->start_ms = song->start_ms;
 	ret->end = song->end;
+	ret->end_ms = song->end_ms;
 	ret->last_modified = song->last_modified;
 	ret->pos = song->pos;
 	ret->id = song->id;
@@ -397,11 +414,27 @@ mpd_song_get_start(const struct mpd_song *song)
 }
 
 unsigned
+mpd_song_get_start_ms(const struct mpd_song *song)
+{
+	assert(song != NULL);
+
+	return song->start_ms;
+}
+
+unsigned
 mpd_song_get_end(const struct mpd_song *song)
 {
 	assert(song != NULL);
 
 	return song->end;
+}
+
+unsigned
+mpd_song_get_end_ms(const struct mpd_song *song)
+{
+	assert(song != NULL);
+
+	return song->end_ms;
 }
 
 static void
@@ -508,15 +541,19 @@ mpd_song_parse_range(struct mpd_song *song, const char *value)
 	}
 
 	song->start = start > 0.0 ? (unsigned)start : 0;
+	song->start_ms = start > 0.0 ? (unsigned)(start * 1000) : 0;
 
 	if (end > 0.0) {
 		song->end = (unsigned)end;
+		song->end_ms = (unsigned)(end * 1000);
 		if (song->end == 0)
 			/* round up, because the caller must sees that
 			   there's an upper limit */
 			song->end = 1;
-	} else
+	} else {
 		song->end = 0;
+		song->end_ms = 0;
+	}
 }
 
 static void


### PR DESCRIPTION
This pr provides some required modifications for the pr ["Some fixes and enhancements about cue files in satellite setup"](https://github.com/MusicPlayerDaemon/MPD/pull/1780) in the MPD repository. It adds ability to parse `real_uri`, `start_ms` and `end_ms` from the server-printed song info.

The commits are detailed in the MPD repo pull request.