### PR TITLE
Try and use XDG_RUNTIME_DIR if no host is set.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -19,6 +19,7 @@ endif
 
 conf.set_quoted('DEFAULT_HOST', get_option('default_host'))
 conf.set('DEFAULT_PORT', get_option('default_port'))
+conf.set('DEFAULT_TIMEOUT', get_option('default_timeout'))
 
 conf.set('HAVE_STRNDUP', cc.has_function('strndup', prefix: '#define _GNU_SOURCE\n#include <string.h>'))
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -10,6 +10,10 @@ option('default_port', type: 'string',
   value: '6600',
   description: 'The default MPD port')
 
+option('default_timeout', type: 'string',
+  value: '30000',
+  description: 'The default MPD timeout, in milliseconds')
+
 option('tcp', type: 'boolean',
   value: true,
   description: 'Enable TCP support')

--- a/src/internal.h
+++ b/src/internal.h
@@ -40,6 +40,36 @@
 #include <sys/time.h>
 #endif
 
+
+/**
+ * This opaque object represents the connection settings used to
+ * connect to a MPD server.
+ * Call mpd_settings_new() to create a new instance.
+ */
+struct mpd_settings {
+    /**
+     * The hostname, in null-terminated string form.
+     * Can also be a local socket path on UNIX systems.
+     */
+    char *host;
+
+    /**
+     * The port number, as an unsigned integer.
+     */
+    unsigned port;
+
+    /**
+     * The timeout in milliseconds, as an unsigned integer.
+     */
+    unsigned timeout_ms;
+
+    /**
+     * The password used to connect to a MPD server, may be null.
+     */
+    char *password;
+};
+
+
 /**
  * This opaque object represents a connection to a MPD server.  Call
  * mpd_connection_new() to create a new instance.

--- a/src/settings.c
+++ b/src/settings.c
@@ -27,19 +27,12 @@
 */
 
 #include <mpd/settings.h>
+#include "internal.h"
 #include "config.h"
 
 #include <assert.h>
 #include <string.h>
 #include <stdlib.h>
-
-struct mpd_settings {
-	char *host;
-
-	unsigned port, timeout_ms;
-
-	char *password;
-};
 
 /**
  * Parses the password from the host specification in the form


### PR DESCRIPTION
These commits add support for trying `$XDG_RUNTIME_DIR/mpd/socket` first, if no host is specified (either in `mpd_connection_new` or the `MPD_HOST` environment variable. This is the same location MPD will listen on if no bind settings are set.

---

I've refactored `settings.c` and `connection.c`  a bit - `settings.c` now only does explicit setting processing (either via args or envvars), leaving the `mpd_settings` struct fields "unspecified" (NULL or 0), which are later filled in with whatever defaults end up being used in `connection.c`.

There is the potential for issues as there is a small change in behaviour - if no host is specified and no default connections work, `connection->settings->host` will be NULL. A cursory glance at clients using `libmpdclient` suggests most of them assume this can be the case anyway.