### PR TITLE
Refactor connection retry code.

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -166,4 +166,11 @@ mpd_connection_timeout(const struct mpd_connection *connection)
 		: NULL;
 }
 
+/**
+ * Fetches the next alternative set of settings from a settings object.
+ * May return null.
+ */
+const struct mpd_settings *
+mpd_settings_get_next(const struct mpd_settings *settings);
+
 #endif

--- a/src/internal.h
+++ b/src/internal.h
@@ -46,9 +46,14 @@
  */
 struct mpd_connection {
 	/**
-	 * The connection settings.
+	 * The initial set of settings.
 	 */
-	struct mpd_settings *settings;
+	struct mpd_settings *initial_settings;
+
+	/**
+	 * The connection settings in use.
+	 */
+	const struct mpd_settings *settings;
 
 	/**
 	 * The version number received by the MPD server.

--- a/src/settings.c
+++ b/src/settings.c
@@ -223,11 +223,20 @@ mpd_settings_new(const char *host, unsigned port, unsigned timeout_ms,
 
 	if (settings->host == NULL) {
 #ifdef DEFAULT_SOCKET
-		if (port == 0)
+		if (port == 0) {
 			/* default to local socket only if no port was
 			   explicitly configured */
+#ifdef ENABLE_TCP
+			settings->next = mpd_settings_new(DEFAULT_HOST, DEFAULT_PORT, timeout_ms,
+							  reserved, password);
+			if (settings->next == NULL) {
+				mpd_settings_free(settings);
+				return NULL;
+			}
+#endif
+
 			settings->host = strdup(DEFAULT_SOCKET);
-		else
+		} else
 #endif
 			settings->host = strdup(DEFAULT_HOST);
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -28,6 +28,7 @@
 
 #include <mpd/settings.h>
 #include "config.h"
+#include "internal.h"
 
 #include <assert.h>
 #include <string.h>
@@ -62,6 +63,12 @@ struct mpd_settings {
 	 * The password used to connect to a MPD server, may be null.
 	 */
 	char *password;
+
+	/**
+	 * A pointer to the next alternative set of settings to try, if any.
+	 * Null indicates there are no (more) alternatives to try.
+	 */
+	struct mpd_settings *next;
 };
 
 /**
@@ -185,6 +192,8 @@ mpd_settings_new(const char *host, unsigned port, unsigned timeout_ms,
 	if (settings == NULL)
 		return settings;
 
+	settings->next = NULL;
+
 	if (host != NULL) {
 		settings->host = strdup(host);
 		if (settings->host == NULL) {
@@ -244,6 +253,8 @@ mpd_settings_new(const char *host, unsigned port, unsigned timeout_ms,
 void
 mpd_settings_free(struct mpd_settings *settings)
 {
+	if (settings->next != NULL)
+		mpd_settings_free(settings->next);
 	free(settings->host);
 	free(settings->password);
 	free(settings);
@@ -271,4 +282,10 @@ const char *
 mpd_settings_get_password(const struct mpd_settings *settings)
 {
 	return settings->password;
+}
+
+const struct mpd_settings *
+mpd_settings_get_next(const struct mpd_settings *settings)
+{
+	return settings->next;
 }

--- a/src/settings.c
+++ b/src/settings.c
@@ -33,11 +33,34 @@
 #include <string.h>
 #include <stdlib.h>
 
+
+/**
+ * This opaque object represents the connection settings used to
+ * connect to a MPD server.
+ * Call mpd_settings_new() to create a new instance.
+ */
 struct mpd_settings {
+	/**
+	 * The hostname, in null-terminated string form.
+	 * Can also be a local socket path on UNIX systems.
+	 * Should never be null after mpd_settings_new().
+	 */
 	char *host;
 
-	unsigned port, timeout_ms;
+	/**
+	 * The port number, as an unsigned integer.
+	 * Will be 0 if the host field is a local socket path.
+	 */
+	unsigned port;
 
+	/**
+	 * The timeout in milliseconds, as an unsigned integer. Never zero.
+	 */
+	unsigned timeout_ms;
+
+	/**
+	 * The password used to connect to a MPD server, may be null.
+	 */
 	char *password;
 };
 


### PR DESCRIPTION
So, this is a rework of the retry logic in `mpd_connection_new()`, with the eventual goal of adding support for a XDG_RUNTIME_DIR based default socket location. It would also be useful for other alternative defaults added in the future.

The idea is simple: turn the settings structure into a linked list. If a socket connection fails, try the next entry in the list.

---

As this list is built ONLY when no explicit settings are provided, there is a slight change in behaviour - if a user _explicitly_ sets a host value (either via argument or via MPD_HOST) equal in value to DEFAULT_SOCKET, no attempt at connecting to DEFAULT_HOST occurs. In my eyes this is a bugfix (why should an explicit setting trigger different behaviour because it happens to be equal to the default setting?).

I have tested this with Valgrind and see no leaks. Additionally, ASan and UBSan report nothing.

Things that I think could be changed/improved:
 * I'm not 100% sure I like the name of the new `mpd_settings_get_next` function.
 * I put the prototype for this function in `internal.h`, but this might be the wrong place for it. Perhaps a new internal `settings.h`, or make it public? (might be useful if clients wanted to see what was/would be attempted)