### PR TITLE
feat: Add ShowMovement Tag

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@ libmpdclient 2.23 (not yet released)
 * support MPD protocol 0.24.0
   - allow window for listplaylist and listplaylistinfo
   - command "playlistlength"
+  - tag "ShowMovement"
 * Support open end for mpd_search_add_window
 
 libmpdclient 2.22 (2023/12/22)

--- a/include/mpd/tag.h
+++ b/include/mpd/tag.h
@@ -20,6 +20,7 @@
  *                                            #MPD_TAG_LOCATION.
  * @since libmpdclient 2.21 added support for #MPD_TAG_MOOD,
  *                                            #MPD_TAG_TITLE_SORT.
+ * @since libmpdclient 2.23 added support for #MPD_TAG_SHOWMOVEMENT.
  */
 enum mpd_tag_type
 {
@@ -69,6 +70,7 @@ enum mpd_tag_type
 	MPD_TAG_MOOD,
 	MPD_TAG_TITLE_SORT,
 	MPD_TAG_MUSICBRAINZ_RELEASEGROUPID,
+	MPD_TAG_SHOWMOVEMENT,
 
 	/* IMPORTANT: the ordering of tag types above must be
 	   retained, or else the libmpdclient ABI breaks */

--- a/src/tag.c
+++ b/src/tag.c
@@ -47,6 +47,7 @@ static const char *const mpd_tag_type_names[MPD_TAG_COUNT] =
 	[MPD_TAG_MOOD] = "Mood",
 	[MPD_TAG_TITLE_SORT] = "TitleSort",
 	[MPD_TAG_MUSICBRAINZ_RELEASEGROUPID] = "MUSICBRAINZ_RELEASEGROUPID",
+	[MPD_TAG_SHOWMOVEMENT] = "ShowMovement",
 };
 
 const char *


### PR DESCRIPTION
Implements the client support for the `ShowMovement` tag introduced in [PR](https://github.com/MusicPlayerDaemon/MPD/pull/2085) / [commit](e3809bd4f07db1a1922e74756e603120430bc82f).