### PR TITLE
Fix typo in MPD_STICKER_OP_UNKOWN and MPD_STICKER_SORT_UNKOWN

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,5 @@
 libmpdclient 2.25 (not yet released)
+* fix typos in MPD_STICKER_SORT_UNKOWN and MPD_STICKER_SORT_UNKOWN
 
 libmpdclient 2.24 (2025/08/23)
 * fix missing "mpd_send_list_tag_types_available" in libmpdclient.ld

--- a/include/mpd/sticker.h
+++ b/include/mpd/sticker.h
@@ -23,7 +23,8 @@ struct mpd_connection;
  * Comparison operators for sticker search api
  */
 enum mpd_sticker_operator {
-	MPD_STICKER_OP_UNKOWN = -1,
+	MPD_STICKER_OP_UNKOWN = -1,   // Keep typo, else we break the abi
+	MPD_STICKER_OP_UNKNOWN = -1,
 	MPD_STICKER_OP_EQ,
 	MPD_STICKER_OP_GT,
 	MPD_STICKER_OP_LT,
@@ -38,7 +39,8 @@ enum mpd_sticker_operator {
  * Sort by settings for sticker search api
  */
 enum mpd_sticker_sort {
-	MPD_STICKER_SORT_UNKOWN = -1,
+	MPD_STICKER_SORT_UNKOWN = -1,   // Keep typo, else we break the abi
+	MPD_STICKER_SORT_UNKNOWN = -1,
 	MPD_STICKER_SORT_URI,
 	MPD_STICKER_SORT_VALUE,
 	MPD_STICKER_SORT_VALUE_INT,

--- a/src/sticker.c
+++ b/src/sticker.c
@@ -251,7 +251,8 @@ static const char *get_sticker_oper_str(enum mpd_sticker_operator oper) {
 	case MPD_STICKER_OP_LT_INT:      return "lt";
 	case MPD_STICKER_OP_CONTAINS:    return "contains";
 	case MPD_STICKER_OP_STARTS_WITH: return "starts_with";
-	case MPD_STICKER_OP_UNKOWN:      return NULL;
+	case MPD_STICKER_OP_UNKOWN:
+	case MPD_STICKER_OP_UNKNOWN:     return NULL;
 	}
 	return NULL;
 }
@@ -293,7 +294,8 @@ static const char *get_sticker_sort_name(enum mpd_sticker_sort sort) {
 	case MPD_STICKER_SORT_URI:       return "uri";
 	case MPD_STICKER_SORT_VALUE:     return "value";
 	case MPD_STICKER_SORT_VALUE_INT: return "value_int";
-	case MPD_STICKER_SORT_UNKOWN:    return NULL;
+	case MPD_STICKER_SORT_UNKOWN:
+	case MPD_STICKER_SORT_UNKNOWN:    return NULL;
 	}
 	return NULL;
 }


### PR DESCRIPTION
We keep both enums and add additional enums to not break the abi.