### PR TITLE
Prevent SIGPIPE being sent

### DIFF
--- a/src/async.c
+++ b/src/async.c
@@ -214,7 +214,7 @@ mpd_async_write(struct mpd_async *async)
 		return true;
 
 	nbytes = send(async->fd, mpd_buffer_read(&async->output), size,
-		      MSG_DONTWAIT);
+		      MSG_DONTWAIT | MSG_NOSIGNAL);
 	if (nbytes < 0) {
 		/* I/O error */
 

--- a/src/socket.c
+++ b/src/socket.c
@@ -28,6 +28,9 @@
 #ifndef MSG_DONTWAIT
 #  define MSG_DONTWAIT 0
 #endif
+#ifndef MSG_NOSIGNAL
+#  define MSG_NOSIGNAL 0
+#endif
 
 #ifdef _WIN32
 


### PR DESCRIPTION
When trying to call `mpd_async_write` for a server that has disconnected, `send` makes the kernel generate SIGPIPE, which will terminate the calling process if it is not ignored. (Some clients like ncmpcpp ignore SIGPIPE, and use the EPIPE error generated by `send` to handle the error which seems like the sensible thing to do.)

This SIGPIPE can confuse processes which rely on SIGPIPE to terminate when the reading end of stdout has been closed. (like a status bar content generator.)

This sets the `MSG_NOSIGNAL` flag for `send`, which prevents SIGPIPE from being sent.