### PR TITLE
Fix strdup on NULL song->real_uri

### DIFF
--- a/src/song.c
+++ b/src/song.c
@@ -219,7 +219,10 @@ mpd_song_dup(const struct mpd_song *song)
 		} while (src_tag != NULL);
 	}
 
-	ret->real_uri = strdup(song->real_uri);
+	if (song->real_uri != NULL) {
+		ret->real_uri = strdup(song->real_uri);
+	}
+
 	ret->duration = song->duration;
 	ret->duration_ms = song->duration_ms;
 	ret->start = song->start;


### PR DESCRIPTION
Guard against a NULL. On macOS this results in a SIGSEGV

```
Thread 0 (crashed):
  0  libsystem_platform.dylib  _platform_strlen + 4
  1  libsystem_c.dylib         strdup + 24
  2  libmpdclient.2.dylib      mpd_song_dup + 112
  3  ncmpcpp                   MPD::Item::Item(mpd_entity*)                     mpdpp.h:231
```